### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.14",
  "serde 1.0.136",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -777,6 +777,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1387,6 +1393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -2074,9 +2089,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
+checksum = "31264b0d765fc0ece5a8366439647c0b30fc67691b9674cc31cee2dc845cab08"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -2089,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
+checksum = "4ffe2d027566e546cce7ae4caa418234fc2033eb655bd52e511feae9b65d4e9b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2101,14 +2116,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
+checksum = "84f73ee13a5dee162fe0576aa6e4818645a21940c0ee42349c961f68b6de6fc0"
 dependencies = [
  "hostname",
- "lazy_static",
  "libc",
- "regex",
  "rustc_version 0.4.0",
  "sentry-core",
  "uname",
@@ -2116,11 +2129,10 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+checksum = "139f79ea5a4f4a9f4e5a5b91a933943ded3556a0a369d088e8dbdf37c7875594"
 dependencies = [
- "chrono",
  "lazy_static",
  "rand",
  "sentry-types",
@@ -2130,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
+checksum = "d0f73a5d17341accfc6b9d0b73adf118649f88ed6a0f8ca23bb524a50159d4ff"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2140,15 +2152,17 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
+checksum = "00348bb8d45f085dec3d966c37c9eaaf4a223578f04a29cdf055e93962b02a55"
 dependencies = [
- "chrono",
  "debugid",
+ "getrandom",
+ "hex",
  "serde 1.0.136",
  "serde_json",
  "thiserror",
+ "time 0.3.7",
  "url",
  "uuid",
 ]
@@ -2551,6 +2565,17 @@ dependencies = [
  "libc",
  "wasi",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,15 +60,15 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-compression"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443ccbb270374a2b1055fc72da40e1f237809cd6bb0e97e66d264cd138473a6"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
 dependencies = [
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -89,10 +100,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backtrace"
-version = "0.3.63"
+name = "backoff"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom",
+ "instant",
+ "rand",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -161,7 +183,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -191,7 +213,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.133",
+ "serde 1.0.136",
  "time",
  "winapi 0.3.9",
 ]
@@ -234,7 +256,7 @@ dependencies = [
  "prometheus",
  "schemars",
  "sentry",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "slog",
@@ -244,7 +266,7 @@ dependencies = [
  "slog-term",
  "structopt",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -253,16 +275,16 @@ dependencies = [
 
 [[package]]
 name = "clevercloud-sdk"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d1a8c56da8237738ec74a2c1f34b553dbf591452f229a4051fcfeab74bd2d3"
+checksum = "9f3346c5f28dc57f3edc2459e93bbdec8eb61abd4f049b9d0c9e3c589e5b6983"
 dependencies = [
  "async-trait",
  "hyper",
  "log",
  "oauth10a",
  "schemars",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_repr",
  "tracing",
  "tracing-futures",
@@ -286,7 +308,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "rust-ini",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -320,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -440,22 +462,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
-]
-
-[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
  "uuid",
 ]
 
@@ -535,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -708,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -725,9 +737,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -737,7 +749,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tracing",
 ]
@@ -844,7 +856,7 @@ dependencies = [
  "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tower-service",
  "tracing",
  "want",
@@ -861,7 +873,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-rustls",
 ]
 
@@ -873,7 +885,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-io-timeout",
 ]
 
@@ -886,7 +898,7 @@ dependencies = [
  "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
 ]
 
@@ -915,7 +927,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -962,9 +974,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -975,7 +987,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "treediff",
 ]
@@ -987,20 +999,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
 dependencies = [
  "log",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
 ]
 
 [[package]]
 name = "k8s-openapi"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8de9873b904e74b3533f77493731ee26742418077503683db44e1b3c54aa5c"
+checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
 dependencies = [
  "base64",
  "bytes 1.1.0",
  "chrono",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-value",
  "serde_json",
 ]
@@ -1017,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.65.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec231e9ec9e84789f9eb414d1ac40ce6c90d0517fb272a335b4233f2e272b1e"
+checksum = "d41f782ddd187a0d8965607679bbd741052106b75330696ce7d7712b13194d88"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1029,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.65.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95dddb1fcced906d79cdae530ff39079c2d3772b2d623088fdbebe610bfa8217"
+checksum = "cced1a3e738c2a4bccb52d33066632369c668f366a71c9c58139d9360e1a341d"
 dependencies = [
  "base64",
  "bytes 1.1.0",
@@ -1052,11 +1064,12 @@ dependencies = [
  "rand",
  "rustls",
  "rustls-pemfile",
- "serde 1.0.133",
+ "secrecy",
+ "serde 1.0.136",
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-tungstenite",
  "tokio-util",
  "tower",
@@ -1066,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.65.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52b6ab05d160691083430f6f431707a4e05b64903f2ffa0095ee5efde759117"
+checksum = "6878656f5e349ef08b0a48d2b1841f1e68c4cf1ef42524feadad2f9a109dd888"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1076,16 +1089,17 @@ dependencies = [
  "json-patch",
  "k8s-openapi",
  "once_cell",
- "serde 1.0.133",
+ "schemars",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.65.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98ff3d647085c6c025083efad0435890867f4bea042fc62d408ab3aeb1cdf66"
+checksum = "73f5fa510a64791242047fea4d807a5da06514ee714cace4b942d38a1126f0a8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1096,22 +1110,24 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.65.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406280d56304bc79b37af7f78e0d9719a4eebc3f46e5e79663154874b7696a48"
+checksum = "0990fe3ab89a1217e6a4d4952e1ab0a24783265ed413228efbc489a00f86b3da"
 dependencies = [
- "dashmap",
+ "ahash",
+ "backoff",
  "derivative",
  "futures 0.3.19",
  "json-patch",
  "k8s-openapi",
  "kube-client",
+ "parking_lot 0.11.2",
  "pin-project",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
- "smallvec 1.7.0",
+ "smallvec 1.8.0",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tracing",
 ]
@@ -1137,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "linked-hash-map"
@@ -1158,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1376,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "oauth10a"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549dec76d1a0659ae57b6fd21164a2fd7cc03e2308baa90267b10de7e0f03607"
+checksum = "d076ef0e069c0089d48334eb5696fd4e8b67a0d5798017d9bfdb24bff9b02382"
 dependencies = [
  "async-trait",
  "base64",
@@ -1390,7 +1406,7 @@ dependencies = [
  "lazy_static",
  "log",
  "prometheus",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "sha2",
  "thiserror",
@@ -1469,7 +1485,7 @@ dependencies = [
  "pin-project",
  "rand",
  "thiserror",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-stream",
 ]
 
@@ -1500,7 +1516,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -1548,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
+ "lock_api 0.4.6",
  "parking_lot_core 0.8.5",
 ]
 
@@ -1577,7 +1593,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.10",
- "smallvec 1.7.0",
+ "smallvec 1.8.0",
  "winapi 0.3.9",
 ]
 
@@ -1717,15 +1733,15 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.25.2"
+version = "2.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+checksum = "00e95f7417529a121d3c1d0bd831fd86cc5d5bf7b77ae1449259db3d5ff8b3e7"
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1845,10 +1861,10 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -1968,7 +1984,7 @@ dependencies = [
  "dyn-clone",
  "indexmap",
  "schemars_derive",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "url",
  "uuid",
@@ -2003,10 +2019,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.4.2"
+name = "secrecy"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde 1.0.136",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2017,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2058,7 +2084,7 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-panic",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2098,7 +2124,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "sentry-types",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
 ]
 
@@ -2120,7 +2146,7 @@ checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
 dependencies = [
  "chrono",
  "debugid",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "thiserror",
  "url",
@@ -2135,9 +2161,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -2161,14 +2187,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.0",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2188,14 +2214,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2211,14 +2237,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2229,7 +2255,7 @@ checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
  "yaml-rust",
 ]
 
@@ -2345,15 +2371,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2385,9 +2411,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2416,9 +2442,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2487,9 +2513,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -2568,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -2645,7 +2671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2666,7 +2692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2695,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
 dependencies = [
  "rustls",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "webpki",
 ]
 
@@ -2707,7 +2733,7 @@ checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2771,7 +2797,7 @@ checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
 dependencies = [
  "futures-util",
  "log",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tungstenite",
 ]
 
@@ -2820,7 +2846,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "slab",
- "tokio 1.15.0",
+ "tokio 1.16.1",
 ]
 
 [[package]]
@@ -2829,7 +2855,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2842,7 +2868,7 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -2851,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ee603d6e665ecc7e0f8d479eedb4626bd4726f0ee6119cee5b3a6bf184cac0"
+checksum = "03650267ad175b51c47d02ed9547fc7d4ba2c7e5cb76df0bed67edd1825ae297"
 dependencies = [
  "async-compression",
  "base64",
@@ -2865,7 +2891,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tokio 1.15.0",
+ "tokio 1.16.1",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -2954,13 +2980,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
+checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
 dependencies = [
  "ansi_term",
  "sharded-slab",
- "smallvec 1.7.0",
+ "smallvec 1.8.0",
  "thread_local",
  "tracing-core",
  "tracing-log",
@@ -3064,7 +3090,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3086,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3125,9 +3151,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3135,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3150,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3162,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3172,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3185,15 +3211,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3270,3 +3296,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["kubernetes", "operator", "clevercloud", "openshift"]
 [dependencies]
 async-trait = "^0.1.52"
 chrono = "^0.4.19"
-clevercloud-sdk = { version = "^0.5.3", features = ["jsonschemas"] }
+clevercloud-sdk = { version = "^0.5.4", features = ["jsonschemas"] }
 config = "^0.11.0"
 futures = "^0.3.19"
 hostname = "^0.3.1"
@@ -51,9 +51,9 @@ schemars = { version = "^0.8.8", features = [
     "bytes",
     "url",
 ] }
-sentry = { version = "^0.23.0", optional = true }
-serde = { version = "^1.0.133", features = ["derive"] }
-serde_json = { version = "^1.0.74", features = [
+sentry = { version = "^0.24.2", optional = true }
+serde = { version = "^1.0.136", features = ["derive"] }
+serde_json = { version = "^1.0.78", features = [
     "preserve_order",
     "float_roundtrip",
 ] }
@@ -65,10 +65,10 @@ slog-scope = "^4.4.0"
 slog-stdlog = { version = "^4.1.0", optional = true }
 structopt = { version = "^0.3.26", features = ["paw"] }
 thiserror = "^1.0.30"
-tokio = { version = "^1.15.0", features = ["full"] }
+tokio = { version = "^1.16.1", features = ["full"] }
 tracing = { version = "0.1.29", optional = true }
 tracing-futures = { version = "^0.2.5", features = ["tokio"], optional = true }
-tracing-subscriber = { version = "^0.3.5", optional = true }
+tracing-subscriber = { version = "^0.3.7", optional = true }
 tracing-opentelemetry = { version = "^0.16.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "^0.3.19"
 hostname = "^0.3.1"
 hyper = { version = "^0.14.16", features = ["server", "tcp", "http1"] }
 json-patch = "^0.2.6"
-kube = { version = "^0.65.0", default-features = false, features = [
+kube = { version = "^0.68.0", default-features = false, features = [
     "client",
     "rustls-tls",
     "ws",
@@ -29,9 +29,9 @@ kube = { version = "^0.65.0", default-features = false, features = [
     "derive",
     "jsonpatch",
 ] }
-kube-derive = "^0.65.0"
-kube-runtime = "^0.65.0"
-k8s-openapi = { version = "^0.13.1", default-features = false, features = [
+kube-derive = "^0.68.0"
+kube-runtime = "^0.68.0"
+k8s-openapi = { version = "^0.14.0", default-features = false, features = [
     "v1_21",
 ] }
 lazy_static = { version = "^1.4.0", optional = true }
@@ -63,7 +63,7 @@ slog-async = "^2.7.0"
 slog-term = "^2.8.0"
 slog-scope = "^4.4.0"
 slog-stdlog = { version = "^4.1.0", optional = true }
-structopt = { version = "^0.3.25", features = ["paw"] }
+structopt = { version = "^0.3.26", features = ["paw"] }
 thiserror = "^1.0.30"
 tokio = { version = "^1.15.0", features = ["full"] }
 tracing = { version = "0.1.29", optional = true }

--- a/src/svc/crd/mongodb.rs
+++ b/src/svc/crd/mongodb.rs
@@ -2,7 +2,10 @@
 //!
 //! This module provide the mongodb custom resource and its definition
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use clevercloud_sdk::{
@@ -221,23 +224,23 @@ impl ControllerBuilder<MongoDb> for Reconciler {
 impl k8s::Reconciler<MongoDb> for Reconciler {
     type Error = ReconcilerError;
 
-    async fn upsert(ctx: &Context<State>, origin: &MongoDb) -> Result<(), ReconcilerError> {
+    async fn upsert(ctx: &Context<State>, origin: Arc<MongoDb>) -> Result<(), ReconcilerError> {
         let State {
             kube,
             apis,
             config: _,
         } = ctx.get_ref();
         let kind = MongoDb::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: set finalizer
 
         info!("Set finalizer on custom resource"; "kind" => &kind, "uid" => &origin.meta().uid,"name" => &name, "namespace" => &namespace);
-        let modified = finalizer::add(origin.to_owned(), ADDON_FINALIZER);
+        let modified = finalizer::add((*origin).to_owned(), ADDON_FINALIZER);
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
         let action = &MongoDbAction::UpsertFinalizer;
@@ -266,7 +269,7 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
                 modified.spec.instance.plan = plan.id.to_owned();
 
                 debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-                let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+                let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
                 let modified =
                     resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
@@ -290,7 +293,7 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
         modified.set_addon_id(Some(addon.id.to_owned()));
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -322,15 +325,15 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
         Ok(())
     }
 
-    async fn delete(ctx: &Context<State>, origin: &MongoDb) -> Result<(), ReconcilerError> {
+    async fn delete(ctx: &Context<State>, origin: Arc<MongoDb>) -> Result<(), ReconcilerError> {
         let State {
             apis,
             kube,
             config: _,
         } = ctx.get_ref();
-        let mut modified = origin.to_owned();
+        let mut modified = (*origin).to_owned();
         let kind = MongoDb::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: delete the addon
@@ -340,7 +343,7 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
         modified.set_addon_id(None);
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -360,7 +363,7 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
         recorder::normal(kube.to_owned(), &modified, action, message).await?;
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
         Ok(())

--- a/src/svc/crd/mysql.rs
+++ b/src/svc/crd/mysql.rs
@@ -2,7 +2,10 @@
 //!
 //! This module provide the mysql custom resource and its definition
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use clevercloud_sdk::{
@@ -221,23 +224,23 @@ impl ControllerBuilder<MySql> for Reconciler {
 impl k8s::Reconciler<MySql> for Reconciler {
     type Error = ReconcilerError;
 
-    async fn upsert(ctx: &Context<State>, origin: &MySql) -> Result<(), ReconcilerError> {
+    async fn upsert(ctx: &Context<State>, origin: Arc<MySql>) -> Result<(), ReconcilerError> {
         let State {
             kube,
             apis,
             config: _,
         } = ctx.get_ref();
         let kind = MySql::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: set finalizer
 
         info!("Set finalizer on custom resource"; "kind" => &kind, "uid" => &origin.meta().uid,"name" => &name, "namespace" => &namespace);
-        let modified = finalizer::add(origin.to_owned(), ADDON_FINALIZER);
+        let modified = finalizer::add((*origin).to_owned(), ADDON_FINALIZER);
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
         let action = &MySqlAction::UpsertFinalizer;
@@ -266,7 +269,7 @@ impl k8s::Reconciler<MySql> for Reconciler {
                 modified.spec.instance.plan = plan.id.to_owned();
 
                 debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-                let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+                let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
                 let modified =
                     resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
@@ -290,7 +293,7 @@ impl k8s::Reconciler<MySql> for Reconciler {
         modified.set_addon_id(Some(addon.id.to_owned()));
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -322,15 +325,15 @@ impl k8s::Reconciler<MySql> for Reconciler {
         Ok(())
     }
 
-    async fn delete(ctx: &Context<State>, origin: &MySql) -> Result<(), ReconcilerError> {
+    async fn delete(ctx: &Context<State>, origin: Arc<MySql>) -> Result<(), ReconcilerError> {
         let State {
             apis,
             kube,
             config: _,
         } = ctx.get_ref();
-        let mut modified = origin.to_owned();
+        let mut modified = (*origin).to_owned();
         let kind = MySql::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: delete the addon
@@ -340,7 +343,7 @@ impl k8s::Reconciler<MySql> for Reconciler {
         modified.set_addon_id(None);
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -360,7 +363,7 @@ impl k8s::Reconciler<MySql> for Reconciler {
         recorder::normal(kube.to_owned(), &modified, action, message).await?;
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
         Ok(())

--- a/src/svc/crd/postgresql.rs
+++ b/src/svc/crd/postgresql.rs
@@ -2,7 +2,10 @@
 //!
 //! This module provide the postgresql custom resource and its definition
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use clevercloud_sdk::{
@@ -221,23 +224,23 @@ impl ControllerBuilder<PostgreSql> for Reconciler {
 impl k8s::Reconciler<PostgreSql> for Reconciler {
     type Error = ReconcilerError;
 
-    async fn upsert(ctx: &Context<State>, origin: &PostgreSql) -> Result<(), ReconcilerError> {
+    async fn upsert(ctx: &Context<State>, origin: Arc<PostgreSql>) -> Result<(), ReconcilerError> {
         let State {
             kube,
             apis,
             config: _,
         } = ctx.get_ref();
         let kind = PostgreSql::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: set finalizer
 
         info!("Set finalizer on custom resource"; "kind" => &kind, "uid" => &origin.meta().uid,"name" => &name, "namespace" => &namespace);
-        let modified = finalizer::add(origin.to_owned(), ADDON_FINALIZER);
+        let modified = finalizer::add((*origin).to_owned(), ADDON_FINALIZER);
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
         let action = &PostgreSqlAction::UpsertFinalizer;
@@ -266,7 +269,7 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
                 modified.spec.instance.plan = plan.id.to_owned();
 
                 debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-                let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+                let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
                 let modified =
                     resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
@@ -290,7 +293,7 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
         modified.set_addon_id(Some(addon.id.to_owned()));
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -322,15 +325,15 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
         Ok(())
     }
 
-    async fn delete(ctx: &Context<State>, origin: &PostgreSql) -> Result<(), ReconcilerError> {
+    async fn delete(ctx: &Context<State>, origin: Arc<PostgreSql>) -> Result<(), ReconcilerError> {
         let State {
             apis,
             kube,
             config: _,
         } = ctx.get_ref();
-        let mut modified = origin.to_owned();
+        let mut modified = (*origin).to_owned();
         let kind = PostgreSql::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: delete the addon
@@ -340,7 +343,7 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
         modified.set_addon_id(None);
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -360,7 +363,7 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
         recorder::normal(kube.to_owned(), &modified, action, message).await?;
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
         Ok(())

--- a/src/svc/crd/redis.rs
+++ b/src/svc/crd/redis.rs
@@ -2,7 +2,10 @@
 //!
 //! This module provide the redis custom resource and its definition
 
-use std::fmt::{self, Display, Formatter};
+use std::{
+    fmt::{self, Display, Formatter},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use clevercloud_sdk::{
@@ -221,23 +224,23 @@ impl ControllerBuilder<Redis> for Reconciler {
 impl k8s::Reconciler<Redis> for Reconciler {
     type Error = ReconcilerError;
 
-    async fn upsert(ctx: &Context<State>, origin: &Redis) -> Result<(), ReconcilerError> {
+    async fn upsert(ctx: &Context<State>, origin: Arc<Redis>) -> Result<(), ReconcilerError> {
         let State {
             kube,
             apis,
             config: _,
         } = ctx.get_ref();
         let kind = Redis::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: set finalizer
 
         info!("Set finalizer on custom resource"; "kind" => &kind, "uid" => &origin.meta().uid,"name" => &name, "namespace" => &namespace);
-        let modified = finalizer::add(origin.to_owned(), ADDON_FINALIZER);
+        let modified = finalizer::add((*origin).to_owned(), ADDON_FINALIZER);
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
         let action = &RedisAction::UpsertFinalizer;
@@ -266,7 +269,7 @@ impl k8s::Reconciler<Redis> for Reconciler {
                 modified.spec.instance.plan = plan.id.to_owned();
 
                 debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-                let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+                let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
                 let modified =
                     resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
@@ -290,7 +293,7 @@ impl k8s::Reconciler<Redis> for Reconciler {
         modified.set_addon_id(Some(addon.id.to_owned()));
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -322,15 +325,15 @@ impl k8s::Reconciler<Redis> for Reconciler {
         Ok(())
     }
 
-    async fn delete(ctx: &Context<State>, origin: &Redis) -> Result<(), ReconcilerError> {
+    async fn delete(ctx: &Context<State>, origin: Arc<Redis>) -> Result<(), ReconcilerError> {
         let State {
             apis,
             kube,
             config: _,
         } = ctx.get_ref();
-        let mut modified = origin.to_owned();
+        let mut modified = (*origin).to_owned();
         let kind = Redis::kind(&()).to_string();
-        let (namespace, name) = resource::namespaced_name(origin);
+        let (namespace, name) = resource::namespaced_name(&*origin);
 
         // ---------------------------------------------------------------------
         // Step 1: delete the addon
@@ -340,7 +343,7 @@ impl k8s::Reconciler<Redis> for Reconciler {
         modified.set_addon_id(None);
 
         debug!("Update information and status of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let modified = resource::patch(kube.to_owned(), &modified, patch.to_owned())
             .and_then(|modified| resource::patch_status(kube.to_owned(), modified, patch))
             .await?;
@@ -360,7 +363,7 @@ impl k8s::Reconciler<Redis> for Reconciler {
         recorder::normal(kube.to_owned(), &modified, action, message).await?;
 
         debug!("Update information of custom resource"; "kind" => &kind, "uid" => &modified.meta().uid,"name" => &name, "namespace" => &namespace);
-        let patch = resource::diff(origin, &modified).map_err(ReconcilerError::Diff)?;
+        let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         resource::patch(kube.to_owned(), &modified, patch.to_owned()).await?;
 
         Ok(())


### PR DESCRIPTION
* Bump clevercloud-sdk to 0.5.4
* Bump sentry to 0.24.2
* Bump serde to 1.0.136
* Bump serde_json to 1.0.78
* Bump tokio to 1.16.1
* Bump tracing-subscriber to 0.3.7
* Bump k8s-openapi to 0.14.0
* Bump kube to 0.68.0
* Bump kube-derive to 0.68.0
* Bump kube-runtime to 0.68.0