### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "1.1.7"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
 
 [[package]]
 name = "iovec"
@@ -1535,13 +1535,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "futures 0.3.21",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
  "js-sys",
  "lazy_static",
  "percent-encoding",
@@ -1554,22 +1556,21 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50ceb0b0e8b75cb3e388a2571a807c8228dabc5d6670f317b6eb21301095373"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "futures-util",
  "http",
  "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
+checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
 dependencies = [
  "async-trait",
  "http",
@@ -1584,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
  "opentelemetry",
 ]
@@ -2604,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
  "integer-encoding",
@@ -3052,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffbf13a0f8b054a4e59df3a173b818e9c6177c02789871f2073977fd0062076"
+checksum = "a73d0f08e0d227c4c63e6d003804946767f4c4f01f52098b56821ae22e336bfc"
 dependencies = [
  "opentelemetry",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ async-trait = "^0.1.52"
 chrono = "^0.4.19"
 clevercloud-sdk = { version = "^0.7.0", features = ["jsonschemas"] }
 config = "^0.11.0"
-futures = "^0.3.19"
+futures = "^0.3.21"
 hostname = "^0.3.1"
-hyper = { version = "^0.14.16", features = ["server", "tcp", "http1"] }
+hyper = { version = "^0.14.17", features = ["server", "tcp", "http1"] }
 json-patch = "^0.2.6"
 kube = { version = "^0.68.0", default-features = false, features = [
     "client",
@@ -35,10 +35,10 @@ k8s-openapi = { version = "^0.14.0", default-features = false, features = [
     "v1_21",
 ] }
 lazy_static = { version = "^1.4.0", optional = true }
-opentelemetry = { version = "^0.16.0", features = [
+opentelemetry = { version = "^0.17.0", features = [
     "rt-tokio",
 ], optional = true }
-opentelemetry-jaeger = { version = "^0.15.0", features = [
+opentelemetry-jaeger = { version = "^0.16.0", features = [
     "rt-tokio",
     "collector_client",
 ], optional = true }
@@ -51,25 +51,25 @@ schemars = { version = "^0.8.8", features = [
     "bytes",
     "url",
 ] }
-sentry = { version = "^0.24.2", optional = true }
+sentry = { version = "^0.24.3", optional = true }
 serde = { version = "^1.0.136", features = ["derive"] }
-serde_json = { version = "^1.0.78", features = [
+serde_json = { version = "^1.0.79", features = [
     "preserve_order",
     "float_roundtrip",
 ] }
 serde_yaml = "^0.8.23"
 slog = { version = "^2.7.0" }
 slog-async = "^2.7.0"
-slog-term = "^2.8.0"
+slog-term = "^2.8.1"
 slog-scope = "^4.4.0"
 slog-stdlog = { version = "^4.1.0", optional = true }
 structopt = { version = "^0.3.26", features = ["paw"] }
 thiserror = "^1.0.30"
 tokio = { version = "^1.16.1", features = ["full"] }
-tracing = { version = "0.1.29", optional = true }
+tracing = { version = "0.1.30", optional = true }
 tracing-futures = { version = "^0.2.5", features = ["tokio"], optional = true }
-tracing-subscriber = { version = "^0.3.7", optional = true }
-tracing-opentelemetry = { version = "^0.16.0", optional = true }
+tracing-subscriber = { version = "^0.3.8", optional = true }
+tracing-opentelemetry = { version = "^0.17.1", optional = true }
 
 [features]
 default = [


### PR DESCRIPTION
* Bump futures to 0.3.21
* Bump hyper to 0.14.17
* Bump opentelemetry to 0.17.0
* Bump opentelemetry-jaeger to 0.16.0
* Bump sentry to 0.24.3
* Bump serde_json to 1.0.79
* Bump slog-term to 2.8.1
* Bump tracing to 0.1.30
* Bump tracing-subscriber to 0.3.8
* Bump tracing-opentelemetry to 0.17.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>