### PR TITLE
Update tokio and kube dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.68.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41f782ddd187a0d8965607679bbd741052106b75330696ce7d7712b13194d88"
+checksum = "86835e9147615457c1edc2b11c723acd1d21372e9cefa80a9d2742f6d69042d0"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.68.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced1a3e738c2a4bccb52d33066632369c668f366a71c9c58139d9360e1a341d"
+checksum = "71f8aa916ee8290fbd0af76b3a28093a8786fccb6286902095a5243484447971"
 dependencies = [
  "base64",
  "bytes 1.1.0",
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.68.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878656f5e349ef08b0a48d2b1841f1e68c4cf1ef42524feadad2f9a109dd888"
+checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.68.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f5fa510a64791242047fea4d807a5da06514ee714cace4b942d38a1126f0a8"
+checksum = "9cd6fdc2e1615a3aecd7e90fe4bda3ba32379e38193251d4ddaccba26579fe22"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.68.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0990fe3ab89a1217e6a4d4952e1ab0a24783265ed413228efbc489a00f86b3da"
+checksum = "32e8bf2258850dbc0a062b561656a1d7020fa8040d552e149f0a0361f0d6794e"
 dependencies = [
  "ahash",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ futures = "^0.3.21"
 hostname = "^0.3.1"
 hyper = { version = "^0.14.17", features = ["server", "tcp", "http1"] }
 json-patch = "^0.2.6"
-kube = { version = "^0.68.0", default-features = false, features = [
+kube = { version = "^0.69.1", default-features = false, features = [
     "client",
     "rustls-tls",
     "ws",
@@ -29,8 +29,8 @@ kube = { version = "^0.68.0", default-features = false, features = [
     "derive",
     "jsonpatch",
 ] }
-kube-derive = "^0.68.0"
-kube-runtime = "^0.68.0"
+kube-derive = "^0.69.1"
+kube-runtime = "^0.69.1"
 k8s-openapi = { version = "^0.14.0", default-features = false, features = [
     "v1_21",
 ] }
@@ -65,7 +65,7 @@ slog-scope = "^4.4.0"
 slog-stdlog = { version = "^4.1.0", optional = true }
 structopt = { version = "^0.3.26", features = ["paw"] }
 thiserror = "^1.0.30"
-tokio = { version = "^1.16.1", features = ["full"] }
+tokio = { version = "^1.17.0", features = ["full"] }
 tracing = { version = "0.1.30", optional = true }
 tracing-futures = { version = "^0.2.5", features = ["tokio"], optional = true }
 tracing-subscriber = { version = "^0.3.8", optional = true }


### PR DESCRIPTION
* Bump kube to 0.69.1
* Bump kube-runtime to 0.69.1
* Bump kube-runtime to 0.69.1
* Bump tokio to 0.17.0

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>