### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "clever-operator"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "clevercloud-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc1a9af3988891d943ef220ff66aceb08ef6506059b02d1a36084640e55b1da"
+checksum = "273547b1a743418354cb83e1912932d7025f1e19c6f5abbb2315acc5efa173ef"
 dependencies = [
  "async-trait",
  "hyper",
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
+checksum = "0e85a1509a128c855368e135cffcde7eac17d8e1083f41e2b98c58bc1a5074be"
 
 [[package]]
 name = "iovec"
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "oauth10a"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0376bdb4d295d4bf50e5395746816d43a4cdaddd58fec86168f8781f56777c38"
+checksum = "85ddc63850a2a065490d3cd5791b3e5f674865e0484e4e76009c91e5f63bd399"
 dependencies = [
  "async-trait",
  "base64",
@@ -2146,7 +2146,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.5",
+ "semver 1.0.6",
 ]
 
 [[package]]
@@ -2293,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "semver-parser"
@@ -2584,15 +2584,15 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3668dd2252f4381d64de0c79e6c8dc6bd509d1cab3535b35a3fc9bafd1241d5"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
  "atty",
- "chrono",
  "slog",
  "term",
  "thread_local",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -2791,7 +2791,14 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinyvec"
@@ -3223,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73d0f08e0d227c4c63e6d003804946767f4c4f01f52098b56821ae22e336bfc"
+checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -3610,6 +3617,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["kubernetes", "operator", "clevercloud", "openshift"]
 [dependencies]
 async-trait = "^0.1.52"
 chrono = "^0.4.19"
-clevercloud-sdk = { version = "^0.7.1", features = ["jsonschemas"] }
+clevercloud-sdk = { version = "^0.7.2", features = ["jsonschemas"] }
 config = "^0.12.0"
 futures = "^0.3.21"
 hostname = "^0.3.1"
@@ -60,16 +60,16 @@ serde_json = { version = "^1.0.79", features = [
 serde_yaml = "^0.8.23"
 slog = { version = "^2.7.0" }
 slog-async = "^2.7.0"
-slog-term = "^2.8.1"
+slog-term = "^2.9.0"
 slog-scope = "^4.4.0"
 slog-stdlog = { version = "^4.1.0", optional = true }
 structopt = { version = "^0.3.26", features = ["paw"] }
 thiserror = "^1.0.30"
 tokio = { version = "^1.17.0", features = ["full"] }
-tracing = { version = "0.1.30", optional = true }
+tracing = { version = "0.1.31", optional = true }
 tracing-futures = { version = "^0.2.5", features = ["tokio"], optional = true }
-tracing-subscriber = { version = "^0.3.8", optional = true }
-tracing-opentelemetry = { version = "^0.17.1", optional = true }
+tracing-subscriber = { version = "^0.3.9", optional = true }
+tracing-opentelemetry = { version = "^0.17.2", optional = true }
 
 [features]
 default = [


### PR DESCRIPTION
* Bump clevercloud-sdk to 0.7.2
* Bump slog-term to 2.9.0
* Bump tracing to 0.1.31
* Bump tracing-subscriber to 0.3.9
* Bump tracing-opentelemetry to 0.17.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>