### PR TITLE
Fix deprecated usage of `parse` attribute method for clap

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,7 +4,7 @@
 use std::{io, net::AddrParseError, path::PathBuf, process::abort, sync::Arc};
 
 use async_trait::async_trait;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use clevercloud_sdk::{
     oauth10a::{
         connector::HttpsConnector,
@@ -96,8 +96,8 @@ impl Executor for Command {
 #[clap(author, version, about)]
 pub struct Args {
     /// Increase log verbosity
-    #[clap(short = 'v', global = true, parse(from_occurrences))]
-    pub verbosity: usize,
+    #[clap(short = 'v', global = true, action = ArgAction::Count)]
+    pub verbosity: u8,
     /// Specify location of kubeconfig
     #[clap(short = 'k', long = "kubeconfig", global = true)]
     pub kubeconfig: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ impl From<opentelemetry::trace::TraceError> for Error {
 #[paw::main]
 #[tokio::main]
 pub(crate) async fn main(args: Args) -> Result<(), Error> {
-    logging::initialize(args.verbosity)?;
+    logging::initialize(args.verbosity as usize)?;
 
     let config = Arc::new(match &args.config {
         Some(path) => Configuration::try_from(path.to_owned())?,


### PR DESCRIPTION
Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>