### PR TITLE
Fix loading of environment variables through config-rs crates

### DIFF
--- a/src/svc/k8s/mod.rs
+++ b/src/svc/k8s/mod.rs
@@ -157,7 +157,7 @@ where
                 .inc();
 
             #[cfg(not(feature = "trace"))]
-            let result = Self::delete(&ctx, obj.to_owned()).await;
+            let result = Self::delete(ctx, obj.to_owned()).await;
             #[cfg(feature = "trace")]
             let result = Self::delete(ctx, obj.to_owned())
                 .instrument(tracing::info_span!("Reconciler::delete"))


### PR DESCRIPTION
* Use std::env::var instead of `config::Environment`
* Load environment variables even if configuration file is provided

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>