### PR TITLE
Update operator-sdk command line interface in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: medyagh/setup-minikube@master
-      - run: curl -L -vvv https://github.com/operator-framework/operator-sdk/releases/download/v1.20.1/operator-sdk_linux_amd64 > /tmp/operator-sdk && chmod +x /tmp/operator-sdk
+      - run: curl -L -vvv https://github.com/operator-framework/operator-sdk/releases/download/v1.22.0/operator-sdk_linux_amd64 > /tmp/operator-sdk && chmod +x /tmp/operator-sdk
       - run: /tmp/operator-sdk olm install --verbose --timeout 30m
       - run: /tmp/operator-sdk run bundle --verbose --timeout 30m 'docker.io/clevercloud/clever-operator-manifest:${{ github.sha }}'
 ...

--- a/docs/21-set-up-operator-sdk-development-environment.md
+++ b/docs/21-set-up-operator-sdk-development-environment.md
@@ -4,7 +4,7 @@
 
 ## Pre-requisites
 
-Before going further, you will need to follow instructions about 
+Before going further, you will need to follow instructions about
 [set up a development environment](20-set-up-development-environment.md).
 
 - The [curl](https://curl.se/) command line


### PR DESCRIPTION
* Bump operator-sdk to 1.22.0

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>