### PR TITLE
release: v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/build-push-action@v2
         with:
-          context: deployments/operator-lifecycle-manager/bundle-0.5.5
+          context: deployments/operator-lifecycle-manager/bundle-0.8.0
           push: 'true'
           tags: clevercloud/clever-kubernetes-operator-manifest:${{ github.sha }}
-          file: deployments/operator-lifecycle-manager/bundle-0.5.5/bundle.Dockerfile
+          file: deployments/operator-lifecycle-manager/bundle-0.8.0/bundle.Dockerfile
   kubernetes-deployment-scripts-validation:
     name: Kubernetes validate deployment scripts
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clever-kubernetes-operator"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "clever-kubernetes-operator"
 description = "A kubernetes operator that expose clever cloud's resources through custom resource definition"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = ["Florentin Dubois <florentin.dubois@clever-cloud.com>"]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ KUBE_VERSION		?= v1.30.0
 
 OLM_SDK		    	?= $(shell which operator-sdk)
 OLM_SDK_VERSION		?= 1.39.1
-OLM_VERSION			?= 0.7.0
+OLM_VERSION			?= 0.8.0
 
 OCP_VALIDATOR		?= $(shell which ocp-olm-catalog-validator)
 OCP_VERSION			?= 0.1.0

--- a/deployments/kubernetes/helm/Chart.yaml
+++ b/deployments/kubernetes/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: clever-kubernetes-operator
 description: A kubernetes operator that expose clever cloud's resources through custom resource definition
 type: application
-version: 0.3.0
-appVersion: "0.7.0"
+version: 0.4.0
+appVersion: "0.8.0"

--- a/deployments/kubernetes/helm/values.yaml
+++ b/deployments/kubernetes/helm/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: clevercloud/clever-kubernetes-operator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "38d856d984753a7cf6d406aaa1f5576b5cd26236"
+  tag: "3e427f3bb10071bd95811ba74a6a71bd247a8fb7"
 
 # Declare your secrets for the operator to create add-ons on Clever Cloud
 config:

--- a/deployments/kubernetes/v1.30.0/20-deployment.yaml
+++ b/deployments/kubernetes/v1.30.0/20-deployment.yaml
@@ -150,7 +150,7 @@ spec:
         secret:
           secretName: clever-kubernetes-operator-configuration
       containers:
-        - image: clevercloud/clever-kubernetes-operator:38d856d984753a7cf6d406aaa1f5576b5cd26236
+        - image: clevercloud/clever-kubernetes-operator:3e427f3bb10071bd95811ba74a6a71bd247a8fb7
           imagePullPolicy: Always
           name: clever-kubernetes-operator
           command: ["/usr/local/bin/clever-kubernetes-operator"]

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/bundle.Dockerfile
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/bundle.Dockerfile
@@ -1,0 +1,24 @@
+# See https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md#Bundle-Dockerfile
+
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=clever-kubernetes-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Label for OpenShift.
+LABEL com.redhat.openshift.versions=v4.6-v4.12
+
+# Copy files to locations specified by labels.
+ADD manifests /manifests/
+ADD metadata /metadata/
+ADD tests/scorecard /tests/scorecard/
+

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-azimutt.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-azimutt.crd.yaml
@@ -1,0 +1,72 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: azimutts.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Azimutt
+    plural: azimutts
+    shortNames: []
+    singular: azimutt
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Azimutt
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-cellar.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-cellar.crd.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cellars.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Cellar
+    plural: cellars
+    shortNames: []
+    singular: cellar
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Url
+      jsonPath: .status.url
+      name: url
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+              url:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Cellar
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-config-provider.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-config-provider.crd.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configproviders.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: ConfigProvider
+    plural: configproviders
+    shortNames:
+    - cp
+    singular: configprovider
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              organisation:
+                type: string
+              variables:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - organisation
+            - variables
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: ConfigProvider
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-elasticsearch.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-elasticsearch.crd.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: elasticsearches.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: ElasticSearch
+    plural: elasticsearches
+    shortNames:
+    - es
+    singular: elasticsearch
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Version
+      jsonPath: .spec.options.version
+      name: version
+      type: integer
+    - description: Cold encryption
+      jsonPath: .spec.options.encryption
+      name: encrypted
+      type: boolean
+    - description: Kibana
+      jsonPath: .spec.options.kibana
+      name: kibana
+      type: boolean
+    - description: Application Performance Monitoring
+      jsonPath: .spec.options.apm
+      name: apm
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                properties:
+                  apm:
+                    type: boolean
+                  encryption:
+                    type: boolean
+                  kibana:
+                    type: boolean
+                  version:
+                    enum:
+                    - 7
+                    - 8
+                    - 9
+                    type: integer
+                required:
+                - apm
+                - encryption
+                - kibana
+                - version
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - options
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: ElasticSearch
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-keycloak.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-keycloak.crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keycloaks.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Keycloak
+    plural: keycloaks
+    shortNames:
+    - kc
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: URL
+      jsonPath: .status.url
+      name: url
+      type: string
+    - description: Admin URL
+      jsonPath: .status.admin_url
+      name: admin_url
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+              admin_url:
+                nullable: true
+                type: string
+              url:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Keycloak
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-kv.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-kv.crd.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kvs.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: KV
+    plural: kvs
+    shortNames: []
+    singular: kv
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  region:
+                    type: string
+                required:
+                - region
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: KV
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-matomo.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-matomo.crd.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: matomos.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Matomo
+    plural: matomos
+    shortNames: []
+    singular: matomo
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Url
+      jsonPath: .status.url
+      name: url
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+              url:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Matomo
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-metabase.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-metabase.crd.yaml
@@ -1,0 +1,80 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metabases.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Metabase
+    plural: metabases
+    shortNames:
+    - mb
+    singular: metabase
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Url
+      jsonPath: .status.url
+      name: url
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+              url:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Metabase
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-mongodb.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-mongodb.crd.yaml
@@ -1,0 +1,91 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mongodbs.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: MongoDb
+    plural: mongodbs
+    shortNames:
+    - mo
+    singular: mongodb
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Version
+      jsonPath: .spec.options.version
+      name: version
+      type: integer
+    - description: Cold encryption
+      jsonPath: .spec.options.encryption
+      name: encrypted
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                properties:
+                  encryption:
+                    type: boolean
+                  version:
+                    enum:
+                    - 403
+                    type: integer
+                required:
+                - encryption
+                - version
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - options
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: MongoDb
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-mysql.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-mysql.crd.yaml
@@ -1,0 +1,93 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: MySql
+    plural: mysqls
+    shortNames:
+    - my
+    singular: mysql
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Version
+      jsonPath: .spec.options.version
+      name: version
+      type: integer
+    - description: Cold encryption
+      jsonPath: .spec.options.encryption
+      name: encrypted
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                properties:
+                  encryption:
+                    type: boolean
+                  version:
+                    enum:
+                    - 57
+                    - 80
+                    - 84
+                    type: integer
+                required:
+                - encryption
+                - version
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - options
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: MySql
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-otoroshi.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-otoroshi.crd.yaml
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: otoroshis.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Otoroshi
+    plural: otoroshis
+    shortNames: []
+    singular: otoroshi
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Url
+      jsonPath: .status.url
+      name: url
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                default: {}
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+              url:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Otoroshi
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-postgresql.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-postgresql.crd.yaml
@@ -1,0 +1,98 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: postgresqls.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: PostgreSql
+    plural: postgresqls
+    shortNames:
+    - pg
+    singular: postgresql
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Version
+      jsonPath: .spec.options.version
+      name: version
+      type: integer
+    - description: Cold encryption
+      jsonPath: .spec.options.encryption
+      name: encrypted
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                properties:
+                  encryption:
+                    type: boolean
+                  version:
+                    enum:
+                    - 11
+                    - 12
+                    - 13
+                    - 14
+                    - 15
+                    - 16
+                    - 17
+                    - 18
+                    type: integer
+                required:
+                - encryption
+                - version
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - options
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: PostgreSql
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-pulsar.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-pulsar.crd.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulsars.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Pulsar
+    plural: pulsars
+    shortNames:
+    - pulse
+    - pul
+    singular: pulsar
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  region:
+                    type: string
+                required:
+                - region
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Pulsar
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-redis.crd.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator-redis.crd.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redis.api.clever-cloud.com
+spec:
+  group: api.clever-cloud.com
+  names:
+    categories: []
+    kind: Redis
+    plural: redis
+    shortNames:
+    - r
+    singular: redis
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Organisation
+      jsonPath: .spec.organisation
+      name: organisation
+      type: string
+    - description: Addon
+      jsonPath: .status.addon
+      name: addon
+      type: string
+    - description: Region
+      jsonPath: .spec.instance.region
+      name: region
+      type: string
+    - description: Instance
+      jsonPath: .spec.instance.plan
+      name: instance
+      type: string
+    - description: Version
+      jsonPath: .spec.options.version
+      name: version
+      type: integer
+    - description: Cold encryption
+      jsonPath: .spec.options.encryption
+      name: encrypted
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for Spec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              instance:
+                properties:
+                  plan:
+                    type: string
+                  region:
+                    type: string
+                required:
+                - plan
+                - region
+                type: object
+              options:
+                properties:
+                  encryption:
+                    type: boolean
+                  version:
+                    enum:
+                    - 724
+                    - 880
+                    type: integer
+                required:
+                - encryption
+                - version
+                type: object
+              organisation:
+                type: string
+            required:
+            - instance
+            - options
+            - organisation
+            type: object
+          status:
+            nullable: true
+            properties:
+              addon:
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: Redis
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator.clusterserviceversion.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/manifests/clever-kubernetes-operator.clusterserviceversion.yaml
@@ -1,0 +1,880 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: cleveroperator.v0.8.0
+  namespace: clever-kubernetes-operator-system
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Developer Tools, Integration & Delivery, Cloud Provider
+    description: A kubernetes operator that expose clever cloud's resources through custom resource definition
+    certified: "false"
+    containerImage: docker.io/clevercloud/clever-kubernetes-operator:3e427f3bb10071bd95811ba74a6a71bd247a8fb7
+    createdAt: 2026-06-08T14:22:48.000Z
+    repository: https://github.com/CleverCloud/clever-kubernetes-operator
+    alm-examples: |
+      [{
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "PostgreSql",
+        "metadata": {
+          "namespace": "default",
+          "name": "postgresql"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "options": {
+            "version": 13,
+            "encryption": true
+          },
+          "instance": {
+            "region": "par",
+            "plan": "plan_xxxx"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Redis",
+        "metadata": {
+          "namespace": "default",
+          "name": "redis"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "options": {
+            "version": 6010,
+            "encryption": true
+          },
+          "instance": {
+            "region": "par",
+            "plan": "plan_xxxx"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "MySql",
+        "metadata": {
+          "namespace": "default",
+          "name": "mysql"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "options": {
+            "version": 80,
+            "encryption": true
+          },
+          "instance": {
+            "region": "par",
+            "plan": "plan_xxxx"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "MongoDb",
+        "metadata": {
+          "namespace": "default",
+          "name": "mongodb"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "options": {
+            "version": 403,
+            "encryption": true
+          },
+          "instance": {
+            "region": "par",
+            "plan": "plan_xxxx"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1beta1",
+        "kind": "Pulsar",
+        "metadata": {
+          "namespace": "default",
+          "name": "pulsar"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "ConfigProvider",
+        "metadata": {
+          "namespace": "default",
+          "name": "config-provider"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "variables": {
+            "ENV_VAR": "VALUE"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "ElasticSearch",
+        "metadata": {
+          "namespace": "default",
+          "name": "elasticsearch"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "s"
+          },
+          "options": {
+            "version": 7,
+            "encryption": true,
+            "kibana": true,
+            "apm": true
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1alpha1",
+        "kind": "KV",
+        "metadata": {
+          "namespace": "default",
+          "name": "kv"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Keycloak",
+        "metadata": {
+          "namespace": "default",
+          "name": "keycloak"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "base"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Matomo",
+        "metadata": {
+          "namespace": "default",
+          "name": "matomo"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "beta"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Metabase",
+        "metadata": {
+          "namespace": "default",
+          "name": "metabase"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "base"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Azimutt",
+        "metadata": {
+          "namespace": "default",
+          "name": "azimutt"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "free"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Cellar",
+        "metadata": {
+          "namespace": "default",
+          "name": "cellar"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "s"
+          }
+        }
+      }, {
+        "apiVersion": "api.clever-cloud.com/v1",
+        "kind": "Otoroshi",
+        "metadata": {
+          "namespace": "default",
+          "name": "otoroshi"
+        },
+        "spec": {
+          "organisation": "orga_xxxx",
+          "instance": {
+            "region": "par",
+            "plan": "base"
+          }
+        }
+      }]
+spec:
+  displayName: clever-kubernetes-operator
+  description: A kubernetes operator that expose clever cloud's resources through custom resource definition
+  minKubeVersion: v1.30.0
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAP/3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHja7ZpZkhs5DobfeYo5AjcQ5HEILhFzgzn+fEipqt12OdrufpuYUltSKVNcAPwLWB3Of/59w7/4qZJiqKK9jdYiP3XUkSdvenz9zOc5xfo8f/zk96d/+jx8Xsh8VHgtrwu9vV7Tx+cfA71f0+SdfDNQX+8L9ucLo76n798N9J6o+Ip8Cfs90HgPVPLrQnoPMF/bim10/XYLdl6v+2Oj/fUv+FPR1/Y+Bvn+96pEbwsflpxPSSXynEt/LaD4vxTK5M3gmV+4MfGYRUrjOZX2XgkB+SpOnz+DFV1fav3ypu+zlb7K1se78H22an7fUr4Lcvt8/fLzkOTrrDyh/2bm2t/v8nef3/RZR3+Kvv+7d/f77JldzNoIdXtv6mMrzzvuM4byqXtgaS0q/4Qh9HkMHp2qXmRtxxWNx0ojZdJ1U007zXTTeV5XWiyx5hOy8ibnRdL8w140j7yK56/6I92sZHWXTl4XaS98mj/Xkp5pR1zhma0z807cmhODJb7y24/wu1+416GQUuyfsWJdOT+gTR7G4s/cRkbSfQdVngB/PL7/8bwWMigeZYfIILD2GsIk/cEE5Ul04Ubh9QWXpPs9ACFiamExoKEmspaKpJai5qwpEchOgiZLz6VmIwNJJG8WmWspjdz07FPzFU3PrVkyHwc+h8zIhONLyQ24I1m1CvWjtVNDU4pUEWmi0mXIbKXVJq01bU6KU4vWoKJNVbsOnb302qW3rr330efIo0CaMtrQ0ccYczLnZOTJtyc3zGnZilWTYM3Uug2bi/JZdclqS1dfY82dd9nwx25bd99jz5MOpXTqkdOOnn7GmZdSuyXceuW2q7ffcedn1t5p/eHxG1lL76zlJ1N+o35mjU9VP4ZITifiOSNhOdRExtVTQEFnz1nsqdbsmfOcxZFBhWQWKZ6znTxjZLCelOWmj9yF/MqoZ+4f5S1o/VPe8t/NXPDU/WbmfszbV1nbLkPrydgLhR7UWEAf10+fuU8Xux9ew88u/O7r//JAtqecfmc/JlrztnoMc3OynJO0U/KStaddbEwSs0s5aTbyksV0zytjpHbnCdZvPkkWRSO2r5me0tOZlMbY0hclyqwttSlK9eU7xqFU+WXPrT2ffSrVdcKiVM243ZKNWu6uesfJ1ocZhTYsDVvTRpdZ9FI4/t9Mc/a1qzWoDyxM60H13MnCL3S4EyZOKpARfwdMf/01/PoXANJJ43ZNEyiMnCtb65tdU/oWWPYt1ql2Sv0IqFBZt+w8m5S+RIjILqCSdOwoiGV00p6nNRAZ+ziAeJ0UJMMRa7Fz7pruTJm3VkO5097HNhoQbay7B8xjvWO0iFhCctfFWV3k3na8ocYbSSdSbp3sE/l4Sydbe9VxS+3XA9jSiseJMO1sjdjO2fJglqgURcmnB3YCE9hhE7vcuo1dtTXyzqttbjTtq0F+eic4r5dyWmnXc+7ZqrXOcfeeGoPdU2TuueSol9aBPK/XxkIKVedRauDkeSdT2Ex1Z9Hse7S1O1Voq4wkIyQtzSIhdR+xarNcWYnU3c5uuvcSPtkw0DG9Ze4zFsMZa25zEeQicqPaCm3e0sZZ7GIdXaOdyefpXBioziOz9n2yex33EP3MieehFrgkbBEqZqVkjMpetRbQ5FxMzuQuwoF8GcQsae51EQEZ6AGly3fTbcdpeScQMQkhoASEQTMXEmWxQR6zgCU9sxwCU3U2hUsBEfvzZTOftL7OqEb7wtZe8EcEXpUt7s1//1UaWd75XKTFwhb2WM4eJG13fGJSupK9RlkorhBX6ma1UdpZSIaYEMOOPOlNeeFUB4wPpINLCNnq2hYSRETU/WJinE6ptRvXZQOojGQDJ564tWxXMVSvVynjHLJswdSL1jbD4Uk7vKB95MSbyv4rOSBtNUMbF/Ci11SRIFiZfMZbJ+nZeTQLUgBlP/VSVzcS/0YdtnozvNS2YRhB59gou7QTDyU+I2mIipQzO4VKtGGFQAmPTYRMgDioIx0REFQwultxRaTqXLzHVMSfsiSWmVYJMn1qLUHMMGNoveogzNCJWWcKQ5qpkFvT6RkqZEKHVgVGUUqGfSusKYUav4SIHithDoxeBFpix7JsdYAnBMOZVMWWEMUVYVNzNwKDN8YiNFD46JiE1nHtqawD5QQojQyRKzZnxAtnuUmgeOHludQLD5XJ9wUHoLQv+ExYA4xNq0IRG6YtXGYvcoy7gVPiblSpLKotjUiNx8235ryQVWRDa1Mcd7DCXN1p5LmdP6cGdfyUKY0WhcCC5AdYmEW/AFGfqbQl0AGxpicZ9TSnyDEhXXdTEjf+BmLbeK8P0HgOfg0idLkndgK37XbfUoCAyNRTg1BaA6GLxuu09bSD3K37wC/R+ZyyxYzVTZR3a9mXYA167zWtMNCJgw8EXNtn0dxsQZTJORJgH1gbZ5Qb1ilC2LBkhuFwuAcitQVHO7fvAN0d6INSyXOAM3ztfZYPl+3zsRMYSzQCy3YuIHItuAB3+RlIqcY/T7+rEXTa8BFFYYFN0jPSzFrmQ/YYwEYp9LPo7Uk3CPCYTgfh24/U0CSuKRVNkcGQbB3bPQB0NkF3HtI+lHFUQH/XnEBtLTjhGctaeqtx8K4MrG2cSI2vxEIPCO6JtxW4ksiwzOb2ZxFpKivHDg8p+IunqEMYwQgFioXKa7EGHjbpObTAd0QQ4qAEI4oJxdc6I8G/DV6EBl7xJE/lFdLgPnj/quuAOaG56RN4o3aYAmF6WCDg8efFDxDtfheh2p5+gzr0rr6B1bOuU7e/AmfKCXKDL3DL2TM82jMQhLH2INxSS/Nyqcv9Grb+wFB4AWeHiUAjeWhcQVlxGUzCDSljyQcys7B++LDWqKSBw7gD11iJmTcePjpFgI2Y44kCiGo/3fNwzk4wWXat3874kFs9+ig7HuY8wj7cg/RiFMyjY9B4J4dawDECu7k1gDpaUou0GOWVpwvknOKs++EHnsqQIJT3Z1fVO6ARCubLOk5yumt76hTbNMareHv8q1ds8yWQEBs4wesxF3VXvGRY7YHYjqcLX0jl0Dhd0PIHcHt2tFb/VorU+DINlxjT8FGibuzaXVhJTGL3gzVQg7gsh2uq+bRaULn0+Ec8licLr+2+qtDT4i3V3wLPDKviUFBSzBi1D86vYFlBiXp9CG6fnpKC6FCsvTLG54+ZDl/WsUSXFMryYmMQQcgUK9lq9QMMcfiVjpYhRcjlnLgrC8Pc1d5RW0mYRGqQHQE5GGqhv+gPJH7yfWARrZK6P+DnXcT7avji8qxUCDKHOd0bTEPzb9Ko5dCOfNkihR97JhD9V0jr/tuD3k/shge8L+RGTAs9yl1M3An9dTZztFVbNAzIMza/9oNf4tkPczYKJzFXGvHgLTSdgHOMTQzTiyRlEGO8ehs0+UNvbDTPa8HnJdNMI4O03RPoaKIQPEdYPz9o+hkNFWajopLTGNYcf6NWvCfPcAQOh6ms4mIOdSS0fMtYIjFplN3BbLhfxw+CI3xGnBuHQipRhG2tINzWTajT/lDaYYuJyibVCQDgvLX9cPmbqxkq0HGxSTgjKrV+kCyQhWPDPyfZV6ZC9IMkfnUEfw1gaIavJHf9rtt/kCyWBwBTHEheDsc7DZDLBwwNdui4JlnBoErHgWAW/YSIXoTco7R4LZwdjqpXOARnAheSW6WpwbeXN/7a+Zn7QMITHXZJT515B4BXaG456Z3pBOiOruJR3SzSJLsgY6O8HW0o68qDRsQdnLZS13zE13vQ8SNjhm8IFQ9rtCa0h95n/oRYiSw0k19AvEDvzauBSz8F4s9wmDA8GH6C7oZHH94MxL02ccez3DpMVqz0mvPUMqMHV63DbnFtnGzaHbhEehBls8aa8MiX5FxBRQpm8WnesMnLPeLwA7ZTnJspRb58jQgm+jq5hRk98XUjltgK+jbaxDbZmncAIKl9ygJlhxPJh29hctd8E4h3Rj5Fbh2NeQ432FGjr4QU8wzeWKbFfXVh7dl4fQYco31WAGTtCpKxScR8re02aZUCJecFawCn3ULFuKXhaFXaBprfXpE6P4yJfrsTDg3QU2Y4ufwJnQmUcfi+OQfnCd9i07cAdqtriHizILjbmyMRG9TfukZZUkMsSZF2RAU77p2PLtosxAj3GyG5lZK3RFOwjACdoqX9gLE9ohUj+cSw0Ip/VRzhy6qZMOyZkN/0tm6TS6QuMpafi6gLHZyCtLFJdpBm2wV7jALClhd+g/rIHalIKBgKGevpBTbbbASWw2cij9ghWldsI47HjxsEOoeYAyFlrNjigr0pGlRRCaQgjKvC1w0abw3vT/WlxuKidV/Z1UTD1OJNFB+6EGAHuIZwlcb41B65wGX5kcrxo7RSJqvdVm3LbfSyYGzk07EMZgMqoRXjW5PKvv53mOkZQRzJcDeX4+JnMPRawGP5aQtNLTLZQU+mGhBpOnls9EzbaX31kNkWbYDQIp3j1k5gukSXjV94jmcAkPdbY7+4CStJBIDnug0ewuQYhVg0NEb0RNAejuobkww/NtoKQV1oLv2YhyB2d+VLUz0CjTwESKug108iaaRJf3KGc58OpfnZPEwBSxMWGf1ZttMgXdJq+I0MeBqe1P2AtzCIA03ZLCfTZUN+4GgpYmgjw8iPqtNokgK7WFnYe919cbVK60xSUIYDmfvxR3eGdoMc/FAnQa6TdmA7XHCT9HLYh+LOBlo9rprKqnC8LCgdgX2JzJsu3l1N+K1Ty/erSqLsIVk4jK4OikNFaBh85ZnmDThUdQcIdVKV6uYfPh74dT/0dwM/vY/GTeK5KZBltd1E/0qPjokghsjGgFgpDSh5w6aPUV8dzaJeLrWZB/1DFhoPgO0XyR7V33vGAvkRcFAqBejQfWdDFPF/o6anTenAb1f/Y8sV/yM3vGZoMQwEIg5YAhD7AUQa1wKIqAoi0sb34FVaFcfmWl7HE27beC4jcQBr+668sgdLTyPSUnJr8yMQsvYIcB/d7dncbGa5+JKlihTTBXjFmVuBMXJbXm9yCbMypndTufhRpPaQUHg/TvWjCPplxkwpkg4/Goo8DEo7rJFw90Ej/tQTF6Eq6gknt3DNZCwYIfLoMKygspQIaum+l7LH/UEgD9zhDdxamV5sBWg4hhSSocAZFR0K/qcd5nSC8T8CXfN+G6CSVqE9iK2TDVYc0TGog+pBAv0g68ZyE+KN5nmdBnIpIKpMSIaCsPfhOrL6e3UafrmgAU09WxpRA1ELPiaSNOyVHr+NE5L/KQCbhTpvZwX3wWjQc7pufuQzn4afm7Gro1MVeo7dTrdv+LrpbAJ9rOCJ9kMvP8Ra+AJNZzif+fldwr70StroQyfMnVaEL/Pj+5FBuEozjOC0o8H7M5Bufq7BahkHwacvYZF+biHuxsUNOmK8EPmDx0r7NBrCl6aXMvr//5r1NwaiE9z+/4D8F+XGKRb4NheFAAABhWlDQ1BJQ0MgcHJvZmlsZQAAeJx9kT1Iw1AUhU9TpSoVByuIOGSoThZERR21CkWoEGqFVh1MXvojNGlIUlwcBdeCgz+LVQcXZ10dXAVB8AfEzc1J0UVKvC8ptIjxweV9nPfO4b77AKFWYprVNgpoum2mEnExk10RQ6/oRB/VFKIys4xZSUrCd33dI8D3uxjP8r/35+pWcxYDAiLxDDNMm3ideHLTNjjvE0dYUVaJz4lHTGqQ+JHrisdvnAsuCzwzYqZTc8QRYrHQwkoLs6KpEU8QR1VNp3wh47HKeYuzVqqwRp/8heGcvrzEdapBJLCARUgQoaCCDZRgI0a7ToqFFJ3HffwDrl8il0KuDTByzKMMDbLrB/+D37O18uNjXlI4DrS/OM7HEBDaBepVx/k+dpz6CRB8Bq70pr9cA6Y/Sa82tegR0LMNXFw3NWUPuNwB+p8M2ZRdKUgl5PPA+xl9UxbovQW6Vr25Nc5x+gCkaVbJG+DgEBguUPaaz7s7Wuf2753G/H4AsXhywPjKAIsAAA39aVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/Pgo8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA0LjQuMC1FeGl2MiI+CiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIKICAgIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiCiAgICB4bWxuczpHSU1QPSJodHRwOi8vd3d3LmdpbXAub3JnL3htcC8iCiAgICB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIKICAgeG1wTU06RG9jdW1lbnRJRD0iZ2ltcDpkb2NpZDpnaW1wOmY5NDQxYjc2LWNiOWQtNGJkOS1hMTlhLWE1MWI5YjYyZjBhYiIKICAgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo3YTJhNmFkYy01YTA5LTRiNTQtYTdiZi1iNDMxZWQwZTJlNGQiCiAgIHhtcE1NOk9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MWRlMjU3Yi0zY2M1LTQxMjktODg3My0xMGE3NmQ1ODMxZmMiCiAgIEdJTVA6QVBJPSIyLjAiCiAgIEdJTVA6UGxhdGZvcm09IkxpbnV4IgogICBHSU1QOlRpbWVTdGFtcD0iMTYzMjIxODE3NzAxOTEzNSIKICAgR0lNUDpWZXJzaW9uPSIyLjEwLjI4IgogICBkYzpGb3JtYXQ9ImltYWdlL3BuZyIKICAgdGlmZjpPcmllbnRhdGlvbj0iMSIKICAgeG1wOkNyZWF0b3JUb29sPSJHSU1QIDIuMTAiPgogICA8eG1wTU06SGlzdG9yeT4KICAgIDxyZGY6U2VxPgogICAgIDxyZGY6bGkKICAgICAgc3RFdnQ6YWN0aW9uPSJzYXZlZCIKICAgICAgc3RFdnQ6Y2hhbmdlZD0iLyIKICAgICAgc3RFdnQ6aW5zdGFuY2VJRD0ieG1wLmlpZDo5ZWIwMTAxYy01MTVmLTQ2YWItYTQ5Zi05ZTNhMDQ3Yjk0NDAiCiAgICAgIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkdpbXAgMi4xMCAoTGludXgpIgogICAgICBzdEV2dDp3aGVuPSIyMDIxLTA5LTIxVDExOjU0OjA0KzAyOjAwIi8+CiAgICAgPHJkZjpsaQogICAgICBzdEV2dDphY3Rpb249InNhdmVkIgogICAgICBzdEV2dDpjaGFuZ2VkPSIvIgogICAgICBzdEV2dDppbnN0YW5jZUlEPSJ4bXAuaWlkOmZkM2EwZTgxLTE3MzAtNGQ0YS1iMjk3LWIzOTM0ZWJlY2FlNiIKICAgICAgc3RFdnQ6c29mdHdhcmVBZ2VudD0iR2ltcCAyLjEwIChMaW51eCkiCiAgICAgIHN0RXZ0OndoZW49IjIwMjEtMDktMjFUMTE6NTY6MTcrMDI6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWNrZXQgZW5kPSJ3Ij8+UiF81gAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+UJFQk4EOVzcl0AACAASURBVHja7d15nGdVfef/97nfpfaqZscF0ATFLXGJY0xilMbJJDNJnJnMOJmJQIDuxiU63crPZtPYcReD0oDmYQSTCJoZGGgSo4AzMSZGlKVRAYXeu6vX2qu++93O5/dHoyI23VXV3/37ev7X1VXf772fe+85n3PuWSQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALBEtuHN+R++9M15IgH0poAQAL2ncON7f28iPPF/F08s3/aNV//Om4gI0HscIQB6R/EvrnqZj+NPm7fXTH5rZzapxTp0MIzMue/lsm7d6++/5xGiBJAAAOgSdtOGE0uVygdM9idmypR2zmwp7Jw+R5LKxfTxhUL8YjmXOrnPOuU+uHLzV6aJGkACAKBTK/5/2pAtPVpd481/WNKJkqQkPXjgn7c/S/bT3zt0INrvzT/nyUJh3sm9T6O/9rmV39yQEEWABABABynduP63vLfrzPSSp/587gcHStWp4vBTfxaGvjAzHY3+TOHg3BMK3DvPe/CefySaAAkAgDZX+8wVZ0dJeo1J//np/xfNVw9MPzT+7CP93fRUtC+K/HN/rpBw7qu5TOY9v/nA17YSXYAEAECbsZvXjxRLdpXk3mOy/BEe9uTQfbuyaSU64t8niWlqIoxNyv18EqDY5D41ptGPvXrz7QtEGyABANDqit82BMXPVC5Qqk+Y7LRn+r3K+HxpfuvE8NE+q1BICqViMvrMBYabsowuP+93f+1v3IYNnugDJAAAWqBww5W/YT7dKNmvHPUXU6sd+tb2fp/4YyQT0sShsOy9DR214HD6vgXZtW988Gv/wlUASAAANEnlM1efEafxx2T2lsX8/vyPDqlyYHE997Wq97Oz0aIWCXPOfdn6Mle98b6v7eGqACQAABrEbvvUQOnQwcu83JUyG1zM36TlMJz47u6+p077O5apyagax35gcUmAapL72Kjyf/7qzV+pcJUAEgAAdVS84b1v9qZrZTpjKX83vXmvorml1ctR5DU9FS2tMHFun0yXnffwvbdxtQASAADHqXzje1+Vpm6jyV631L+tHirY3GMHl/Wcz83FabWSZpZRrHwnk3Frz33wnge5egAJAIAlKn3+qtN8NfmQTKtMtvSNu0x+4ts7g7QWL+v709Q0ORml5m3JSYCTzJy7OQgy71/54NcOcTUBEgAAx6q3b9uQLx6svtOc/4BMo8v9nOKOaRV3zRxfElJMVCgsfzVgJ5XM6c/OPDVzwwvuvjvk6gIkAACOYOH6y39XsutkdvbxfI6PEpv4153OvB3X8ZhJUxOhT1I7vq3DnXYGprUrH/76P3CVARIAAD9urV9/5Uu8kk/L9O/q8Xlzjx5QdaJYl2OrVb1mZ6O6fJaT+0cXZNetfOirj3HVARIAoGfZZ684oZT4PzXTO02WrcdnxgtVTT04XtfjnJ6OFIV1WvjPudTJPjOUGfrgrz6waYa7ACABAHqn4r/ttkxp4qE1ZvqwmZ1Utwfayabu3+OiQq2uxxvHpunJ0KyOZYaTmzNnVwcjv/55th0GSACArle6cf0bfWrXmfSyen925cCC5n/UmEH38/OxKuW0EcXQj+SCd79x891f5+4ASACArlP77BW/ECX+k2b2Bw3pVUi9Ju7bJR82pjHtvTQxEep4BxYepTTaFOTd+pXfuXc7dwtAAgB0PLt5/Uix7K6Q/GVm6mvU9xS2Taq0Z66h51IqpSosxA38BhcFzn1qIOs+9tr77y5w9wAkAEDnVfxmrnDDFRc4+U+Y6fRGfldSjTV13y6ZWWPPSdLURKgkaez3yGkiUHD5ub//2lvYdhggAQA6RuHGK3/NfHq9zF7djO+b+cE+hVPlppxbrZZqdiZuTiCdeziQW7ty8z3/yl0FkAAAbaty/frnJtJHzeyCZn1nOFvRzMN7m3qeMzORwlrzGubOBV/KBP7KNzz49b3cZQAJANA27LZPDZQOHnqPd7pqsdv01ueLTZP371FSau4qu0limpoM1eA3Dk9LAlQ1BR8dyI9c++vfub3KXQeQAAAtVbzhiv/iLb1WprOa/d3lvXNa2DLZkvMuLMQqldKmf69zbq/JXfbGzffczt0HkAAATVe+/opXpuavM9nrW/H9PvGa+PZOWZy25Py9N01OhPItGqLnnL4t09rzHv76Zu5GgAQAaHyL/y82nGpx+YMyt2ZZ2/TWycITEyrvm29pLCrlVPPzcQuPwHnndPNgtu/9r73/7ye4OwESAKDu7HOfyxWi7e+UuQ/IbKyVx5KUQ01+d/fheXktNjkZKolbeyDOuaLkNpz2CyM3vvT22yPuVoAEAKhPa/uGy/+9M7vOzF7YDscz8/A+hbPltohNGHrNTLdHnevktstp3Xmb7/0qdy1AAgAsW+GGK19klnxapt9pl2OqTRY1+8iBtorT7GykWrWN1utx7v/mssG6199/94+4iwESAGDR7K82rCgWqn8q2bvqtU1vXXjTxHd3Ka3EbRWvNDFNTEZq6rzAY+YASsy5G/P92Q/+5r9+dY67GiABAJ654r/ttkzp4EOrTPYRk05ut+Mr7Z5VYftUW8auUEhUKrbhrr7OzQbS1ef+wujn3e23p9zlAAkA8DOKG9evNNl1Jv1yOx6fD1NN3rdTPm3PpfG9Hd4nIE2tLY/POT2mIFh33oP3/CN3O0ACAKh6w/ueH1t0jZn913Y+zrkfHVT1QHtvkFetppqbjdv6GJ3cneaC9W/cfPcO7n6QAAA9yD6zYbjgK1c4s/+vkdv01kNcDDX1wO62mPZ3LFNTkeKo3Tfwc6ELdG2+r+/jr/v23xd5GkACAPRCxW/mCjde8Rbn7RqTPasTjnn6oXFF852x/H0UeU1PdcZUfOfcITldvvLBe25xzhlPB0gAgC61cP3610raKLPXdMoxVw4VNP/YwY6K8/xcrEqlc8bbOekhy2jtGx/8+n08JSABALpI+Yb1z07NPibpArPOue8t9Zr8zi6ltaSj4u1T08RE2E6zAhdZILpbXC64auX9d+/jqQEJANDB7K829BcLlXeb7GpJQ512/MUd0yrumunI2JeKiQqFpPMO3LlK4OyjfbmxT7HtMEgAgA5UvH79H3jTtZI9rxOPP63Fmrxvl8x35qtpe3JaYJJ25vE7uT0KdNl5D917B08TSACATmh5Xn/5y738dWY6t5PPY+7RA6pOdPYA9Wot1dxM3Nk3lHPfyrpg7Rseuvt7PF0gAQDassV/5Sne0g866dJWbtNbD9F8VdMPjXfFdZmZjhSGvsPPwnkn+3xf/9Cf/sZ9myZ52kACALSBJ7fpfYe8Nkha0Q3nNH3/HkXFWldcnzg2TU2G3VJiLjgX/NmonXnjqzf/ZczTBxIAoEVKG6/4HS9/ncnO6ZZzquxb0PwTh7rqOs3Px6qUu2gZfue2Zlyw7tyH7r6bpxAkAEATFT67/hzF+pTJ/kM3nZdPvCa/s1M+7K49a7x/clqg76770Dl3byaXffcbvvvVx3kqQQIANJB97vKxYmjvl+x/minXbee3sHVK5fHZrrx25VKqhYXu6zV3TolMN7jRwQ+u/OZd8zylIAEA6lnx24ageEN1lWQfMbNTuvEck0qsye/uOrytXldeQ2lqMlSSdOf5OeemZXb1yl8cu5lth0ECANRB8fr3vsHkNprZy7v5PGe+v0/hdLmrr2Wt5jU7E3X5HeseyTitO3fzvf/E0wsSAGAZqn9xxfPiOL3GTG/u9nMNZyqa+d7enriuszORajXf/Sfq9H+ymb71b3jgK7t4mkECACyCffGTQ4W5qcud03vNrL/7T1iavH+XklLUE9c3ib2mpqKO2ydgmUVsKOnPg9HRj6/85u0lnm6QAABHqgfNXPmGy//Im33CpOf0ynmXx+e0sLW31pYpLMQqlXrnNblz7qAL3PpzH7j7S2w7DBIA4Ckq169/TSJtNLPX9tJ5+zjV5H275OPeGjPmTZqcCOXTHqsLnXsgsGDtyofv/i5PPUgA0NPKn7vqWWkYf1TSH3fSNr31svDEhMr7enPmWLmcamG+9xbTc5LJuVvy/X1Xvu7bf3+AUgAkAOgpdv31fUW3/91mdrXMhnsxBkkp0uT9u9UjL8OPaHIiUpL4Xj39snPBR9zI6Z9e+c2/rlEqgAQAXa9ww/r/ZGafkun5vRyHmYf3KZwt9/S9EIVe09NRT8fAye1Wxl123oP33EnpABIAdKXSDZf/kjfbaGYrez0W1cmi5h6h91eSZmdj1aqsm+Oc+6YyWnfeA/f+gLsCJADojhb/jVeeZGn6QefsrWbK9HxAvGnyO7uVVCNuDklpapqcCHv5TchTi2Qvp78MlH//ys1fmSYeIAFAR7J/2pAtPFp5h6QNMjuBiBxW3DWr4o4pAvHUmBQSFYsJgfhpwTzvnNsworM+y7bDIAFARyndcPlve2+fNtmLicZTGv9RcnjaX+8OfDtysmjSxKGaPGH52QLauS0u0LqVD957D9EACQDaWuHGK18on/y5mX6faPy8uccOqnqoQCCOoFpJNTdHY/fIiYC+Jhe857yH7tlCNEACgPZqwV2/YbToyu+XaW03btNbD1GhpukH9hCIo5ieChVFDAZ4hiQgNrnrxzT6oVdvvn2BiIAEAK2t+G1DULyxcrHMPmqmU4nIUSq3B8cVLVQJxNGSpMg0PRUSiKMW2m7KpKvPe9Ov3ew2bOClCUgA0HyF69/7mya3UWavJBpHVz1U0NxjBwnEIszPxapUmBa4iETgB8oEa8978O5/JhogAUBzKrPPXX5mFNo1MvtDonFs5k2T396pNGSU+2J4f3hAINMCF1uKu9uDnFu/8rv37CYYIAFAYyqyz20YLITVy53595o0QEQWp7h9WsXdMwRiKTErJioWSJgWnwOoJrlPnnTSqZ94+ddvKRMRkACgbkrXv/d/eLlrzOy5RGPx0lqiye/skqW8ql1SsvnkboFpSjfAEu0PpMvP3Xzvl9l2GCQAOC7lG9a/OjVtNLNfJxpLN/fIAVUniwRiGWpVr9lZVktcZo/Ad7POrX39Q/c+QDRAAoCltfg/s+F0n1Q+KmcX9eI2vfUQzVc1/dA4gTgO09ORopDek2UW7mbO/U1Ouur1m+9lBCpIAHB0T27Tu9a8vU+yESKy3EBKUw/sUVxkl9fjkSRekxP0AhxnIV8yp4+ceWrm0y+4+27mWIIEAD+vsPHy/2jOXyvTLxKN41PeP6+FxycIRB0sLMQql5gWWIfSfmcgXbZy89fvIhggAYAkqfgXV73MR8l1kr2RaBw/n3pNfnuXfMQo9vrE8/BugZ4hbfUp9J2+kVF23Rs2f+1RokECgB5lN204sVApf9BJb2Ob3jq2WLdOqjw+RyDqqFxKtbDAPgF1zAJSJ/vcUGboT3/1gU3MUSUBQM9U/P+0IVt6tPI2b/Znkk4kIvWTVmJNfGeXWMWmzvesSVNTkZKYAYH1rQDcnJzb4EZe+9mV39xAlxUJALpZ6cb1v+W9XWemlxCN+pv5wT6FU6zD0ghhmGpmml6ABnncKXj3eQ/fcy+hIAFAl6l95oqzo9Rfa2ZvIhoNqqCmy5r5/j4C0UCzM7FqNQYENtBXsrn8ZW+4/x+2EQoSAHQ4u37DaNHKV0tuncnyRKRRgZYmv7tLSZkpa42UJKapyZA3LI2tFqLAuesHsu5Dr73/7gLxIAFAp9VHtiEo3lC+SOY+arLTiEhjlcfntLB1kkA0QaGQqFTkdXUTTAZBcNW5v/fav2LbYRIAdEoBecOVv2E+3SjZrxCNJiRbcaqJb++UTygjmxJvL01MhPLMC2xSLeG+lzGtPffhe79FMEgA0KYqn7n6jDiJr5HsvxON5ll4/JDK+xcIRDPv9XKq+XkGBDa3snD/O+/y61+3+Susb00CgLZpEd32qYHSxKH15u1ytultrrgUaur+PUz7a4GpyVBxTNyb2xmgquQ+Oar8J169+SsVIkICgBYq3nj5f/feXyPTGUSj+WY271U4RznYCmFkmpliafvWJAJunzm3/o0P3fO3RIMEAE1WvvG9r0pTt9FkryMarVGdLGrukQMEooXmZmNVq0wLbF0F4u5z2czalQ987SGiQQKABit9/qrTfCX5iKSLTRYQkdYwM03dt0tJlffQrZSkpqkJpgW2uBIxyf21y2SuWvng1w4RERIA1LvCuW1DvniostZk75NplIi0VnHXjIo7pglEO1yLYqJigWmBLa9MnCvK6cOnPX/0upfefjsLYnQAWpCdUsgdKH/DzK6h8m+9NExU2j1LINrE8HBWmQxtmZY3UsxGzNsnDu1Y+BeiQQKAOopL4TBRaA+F7VOylDn/7dPylEbGsgSiTVSSzHOIAgkA6iipRC+R2Q4i0VpRoabqQVZHbTeDAxnl8xRnrebNzdZS91wiQQKAelc+89XTnRPDnVpoYcsEQWhTY/QCtJSTrBQHbC9OAoBGSKN0KKkl+4lEa1QPLiheqBGINpXLBxoczBCIVjVQ0kCJMRaDBAANExfC5zq5KpFoLku9CtsZ9d/uRkazCqiDWvCAyMqJI/IkAGjoc+a9ohKrnzVbcdeM0pCpZu0uk3EaHuVVQLNV08B5ZpWTAKDxkko4YN7KRKJJ8a7GKo/PEYgOMTyUUSZLZdQs3qRaSrxJANCkbgApKtSGCERzFLZNyth6tnM4x4DAJqokGRmtfxIANDHrDhNZnLLaVoNF81XVJksEosP092fU10fx1mixd4o8lT8JAJouLIR59qFtIJMWnmDaX6caG8sRhAarplQhJABoTf2UpEqqMel3g5T3zytmwGXHyuachoaZFtgoNR8oofVPAoDWSUqRzBvr0taZTzyb/XSBkZGcAuYF1r/xYVI1pvogAUBrH0RvSsoh17HOijun5WP2me/4Ai6QRkbpBai3ShqwJCkJANqiF6AaszlNPeNZjlTeO08gusTgYFZZpgXWTeqlkHf/JABol24AKS6wRG29LGydZGxlF3FOGmVAYB1b//SokACgvbLyKGWlujoIp0sKZ1hjqdv09wfq76e4O16xd4oZ+EcCgPaTFEPxYu44mGlh2xRx6FKjYzmWqzne1n9ClUECgLbkU6+kwrS15SqNzysps7ZSt8pmnYZG6L5erlrqlLLbHwkA2rgXoByxbO1ykqc4VWkX0/663chwVgGl3tKfD5OqCckTCQDamplYvGYZCtun5RNmUnQ7FzgGBC5DlWl/JADoDGktZg77EsSlUJUDTPvrFYODGeXyFH2LlZhj2h8JADqnG0CKi/QCLNbCExMMnuwxY6PsFrjo1j8r/pEAoLP4OFVSiwnEsQq3iaKi+SqB6DH5vkADAxR/xxKlTjED/0gA0HmSUkTL9ijMm4rbmfbXq0ZHc3LUbUfFoj8kAOjUCi71SipMa3smpd2zSqr0kvSqTNZpeJhXAc+kmgZiQhEJADpYXI7YJ+AI0jBRac8sgehxw8MZZTJ0AzydN6cai/6QAKDTuwGMAYFHUNw2RWIEpgU+A3b7IwFAF7V2fcS0wB+LF2qqHCoQCEiSBgYC5ZkW+BOJd4pSekVIANA9lV6pxoDAJy1smSAI+BljY4wFeGrrHyQA6CI+9kwLlFQ5sKCIrZPxNLl8oMFBRryHaaCE3f5IANB9klIo6+F97i31KuxgvX8c2chotqenBZrY7Y8EAN37gHs7vDZAjyrumpUPE24EHFEm4zQy0rsDAqtJhreEJADo6l6AaiTfg6Pfk2qsMtP+cAxDIxlls73XDeDNKWScMAkAur0boDf3CShsnezp1x9YHCf15LTAchLIxLt/EgB0f7YfJkqj3ukKD+cqqk2VuPBYlP7+QH19vVM0xt4pZuAfCQB6R1wIe2NaoJkKWya54FiS0RW9My2wkjD7gQQAPcVS3xPr4Jf3LygusRIiliaXDTQ01P1JQC0NlPJmjAQAvScphVIXvxf3caoi0/6wTCOjGQVB93aNm0nVhK5/EgD0Zi+AmeJi904LLO2ckY8Z2oxlFo6B08hI9/YCVBn4xz1OCHq8F6AayZLuqySTcqTSvjkuMI7L0HBGuWz3FZOpOdU8xT8JAHpeN04LLGydZO8D1EU3Dgis0PUPEgBIUhqlSrtohbzadEm1mTIXFnXR1xeov797RspH3imm9Q8SAPxYUgzVFU1mMy1sneKCor69AGPZrnlbznr/IAHAz/CpV1Lu/GmBpb1zSisRFxR1lc06DQ13/quAahrIG93/IAHA03sBypHMd+4+AT5KVNoxw4VEQ4yMZpXJdG7l6U2q8e4fJAA4EjNT3MG7BRZ2TPfkRkdoDucOJwGdqpIy7Q8kADiKtBp35Nz5uFhT5cACFxANNTiYUT7XeZVo6qUopbgHCQCOWZl23rTAhS1M+0NzjK7ovN0Cyynr/YMEAIvg41RprXMGBFYniormq1w4NEU+H2hgsHMq1Mg7Jez2BxIALLoXoNQZuwVa6lXYxm5/aHIvwGhWrkP2CWDaH0gAsMSK1ZSU2/9VQGnPrNJawgVDU2UyTsND7d8LUE2Y9gcSACynF6ASydp4VH0aJirtnuVCoSWGR7LKZNu3cvXmVGXgH0gAsLxugPYeEFjYNinzjPxDazh3+FVAu6qktPxBAoDjbGX7qP2mBUYLVVUPFblAaKmBgYzyfe1XjCbmmPYHEgAcv3YcEFjYwsA/tIexNuwFqMQU7SABQB34OFVSbZ9pgZUDC4oKNS4M2kIuH2iwjQYEhmmghIF/IAFAPXsBrA16AXziVdg+zQVBWxkdzbXFtEATA/9AAoC6lyympNT6Vndp94x8xLQ/tFlBGkgjw63vBagmToyLBQkA6i6pxC2dFphUI5X3zHEh0JaGRrLKtnBaoDenGq1/kACgUaJi63oBClunZEbzBu3JSRoda92AwApb/YIEAA1tZYSp0hZ0wYezZdWmSlwAtLX+/oz6+5tfrMbeKfIU5yABQKMLm0KTpwWaaWHrFIFHRxgdy8k1uTHOev8gAUBz6uPUK6lGTfu+8r4FJaWQwKMjZLOuqdMCa6lTyrQ/kACgWZJypGYMN/ZxquJOpv2hs4yMZBU0oXT1kqpphoCDBABN7AXwdniFwAYr7pyWj1MCjs4qWAOnkSasEFhNMmJcLEgA0PxegGosnzSuck7Kocr75gk0OtLQUFbZXOO65lOTQjb8AQkAWiUuNK4XYGHrZNvtQQAsxdhYrmGfXUno+gcJAFrIx6nSWv33CahNlRTOVAgwOlpfX6D+gfoXs5F3ij2tf5AAoNW9AKWovi11MytsY7c/dEkvwGhO9ZwXaHKq0voHCQDagaVecaV+0wJLe+ZcUokJLLpCJuvquk9AmDqlvBoDCQDaRVKOZHWYFmhRYqXdMwQUXWVoJKtM5vh7AUxSlUV/QAKA9uoGMMXF4x8QuLB92vnEE090V0HrVJdpgZU4w7hYkACg/aS1WHYcc/bjYs0qBxcIJLrS4GBGufzyi9zEO4UM/AMJANpVWAzl3PIaKQtbJh3NG3SzsbGs3DKHzFbY6hckAGhnFqdKqvGSmym1iZKP5qsEEF0tnw/UP7j0wQCRD5TQ+gcJANrd4bEAtvh3AaZkYdsk9yJ6oxdgNCs5pYt/PKRKQuUPEgB0Qi+ANyWlaNHznsq7Z4NGLCYEtGWhm3EaGckt+vmoJYE8u/2BBAAd0wtQiSRT7Vi/56O0Utg9w32InjI8nFEm4479fJhU5d0/SADQWd0AUlSo9R/r1wpbJgYsZdofeotz0uhY7pjPB+v9gwQAHenwtED/jPP6klI4U5ko0reJnjQwECifc8+43WXiD6/5D5AAoCNFhdqYO8KAJyfn53548CQihF42dkJ+heT8zz8fsnKSJUAgAUDn8kmqpJpOPf3n1enivnqsHAh0slzOaWAgOPT0n9d84FjvHyQA6PxegGL1dJOVfvoTK80/fuhMIgNIYyuyz3ZOT3k+FLPeP0gA0CXdACZfjn+yv29pfG6/D1PiAkgKAqeRkdxPegGqaSbwtP5BAoCu6QUohb8gadx721fYPn0OEQF+amg4c7Zz2mumyWriGPoPEgB0l2ShViw8PjktmjfAz3BOOmFFfq6SZEtEA83CMFM0TVioBqV9M33xXO2oE/9N5o41+ckk5keh/Sryo2z0Yz/5HXfE35muZXKlpC/OBbweAwkAuq0HYC4cHjp1LDs/XwvM7FgVPNBxFpOYmn5+XV8zabw0MOYltyJPAoDm4BUAmiItxxPe/BkK3LP6TxmZISLATx2s9k2npmeb6Vm1JGB+LEgA0CWtIm9KSrXhH/+7/6ShoSDLrQdIUmJOByr5oR//u5ZmZGz+AxIAdEXrvxSVzDT0lB/1D542RisHkLS31F8108BPEmapjw2AQAKAjudjr7QSDT795/nR/nymP0eA0NMqSUbTtVzf038epYGl9AKABACd3foPYzvCfWaSGzp9jG0A0dP2FPtTyY74fFRilgMACQA6tfUfxkrD5Bmb+ZmBXJAfGyBQ6EkztZxKSfCMtXxiTjG7AYIEAB3HpLQQHbOFP3jqqMlRyKHHkmOT9pfzx5ztWk0yTIkFCQA6S1KJlKb+mPeXywZu4JRhAoaecqCSV+iDY2a+qTmFKa8CQAKADmrepKVw0Q2X/hOHFOQo5NAbotRpoppf9O/XkkCeAYEgAUAniIuhzJawzESqPwAAG/RJREFUVK9zGjhtlMChJ+wt9y2pQjdJTAsECQDav/Efp0qr8ZL/Lj/Sr+xgngCiq5WSQLPh0qe/RmmgRbxRA0gA0NrW/3LRC4BuN15c/qyXcsprAJAAoE2l1VgWLX8jk2x/Tn0nDBJIdKWpWk7lZPlFbuoDhfQCgAQA7cbMlBSj4/6c/pNH5AJaOuiy5Nic9peP/xVXLQlkzAsECQDaqoArRzJ//Av7BdlAA6eMEFB0lf2VvOI6tN69OdWYFggSALRN6z81JaW4bp/Xd+KQgnyWwKIrhKnTZLV+A1xrPhD7BIAEAG0hKYZSndcrGzyVXgB0h/HSQH277U2qJhTdIAFAi/koVVqL6/65uZF+5Ub6CTA6WiHKaj6qf5d97AMlRvENEgC0UFyoNeyzB04dkejpRIcySeOlvoZ9fiUO2CcAJABojbQay5LG7eibyWfVfyL7BKAzTVbyDV3BLzWniBUCQQKApvP25Lv/xuo/aUguw22KzpJ4pwPVxq9sWU3pBQAJAJosLkcy3/iix2UCBgSi4+yr9CnxjX9/ZeZUTZgWCBIANIklXmklbtr35ccGlOnLEXh0hGoaaLravPs1TNktECQAaFbrv1BTU5cjc06D7BOADjFe6mt6t3yFaYEgAUCj+SiVP471/pcrO5RXfpRpgWhvc2FWhaj5i1jFPlDs6QUACQAaxayh0/6OZeCUETlHIYe2fTy0t9y6JLWasHomSADQIGmlsdP+jnmz5rPqO3mIC4G2dKjap7CFW/amJtWYFggSANS9deNNcSlq+XH0nzgsl+W2RXuJvdPBSusHqtaSDNMCQQKA+kqKodphH1IXMCAQ7Wdvqb8tNugxSdWYVwEgAUC9CpUkVVqN2+Z48qMDyvbnuTBoC+Uk0EzYPpVu6J1SBgSCBAD1EBeitjumgdPpBUB7GC8OtN0xVVIWBwIJAI5TWovlo6Ttjis7kFPf2CAXCC01Xcup1IZz8BPvFNELABIALJ8pKUZte3T9pw7LBRRyaA1vTvsrfW17fFUGBIIEAMtuRZRiWerb9+bNZtR/MrsFojUOVvKK0vZNQL05hewTABIALLntn5rSctT2x9l3wrAyOQo5NFfkAx2qtv9A1Grq5OkGAAkAltb6D2XW/iWHC6R+pgWiycZLfR1SsTpVGRAIEgAsuvUft9e0v2PJj/QrO8i0QDRHMc5oLuycufZRGrTFGgUgAUAHiAthxx3z4GljXDg0rfXfacoxvQAgAcAxpNVYPk477rgz/Vn1ncC0QDTWZDWvSgcOrEvNKWSfAJAA4BmZ2nra37EMnDwiF3BLo0GVqHfaX+7cV021NJDxKgAkADiSpBTKvO/Y43fZQAOnjnAh0RD7q3klHVyBenPsFggSAByhcEi9kkrU8efRd8KgMnned6L+refJaucPNA19wLRAkADgaa3/QqRuWTZsgAGBqLO9pT5ZFzwfZurIMQwgAUCDpFEqH8Zdcz654T7lhvu5sKiLhSir+ah7ttiNfaDEU/SDBACSkkKt685pgMWBUI8Ws6S95b6uO69KErBPAEgAer71X4llie+688rkM+o/cYgLjOMyUc2rmnRfMZmaU8SAQBIAQtDDrRt/eOR/t+o7eUQuwy2O5Um804Fy964wWUszDAgkAUDPtv5LNVkXlwBBxmmQaYFYpn3lvq5eQtfb4SQAJADotdZ/4pVU4q4/z/yKQWX6s1xwLEk1CTRdy3X9eYbsE0ACgN4Td+HAv2fCtEAs1Xipv2cGyVUSqgESAPSMNEzlo7Rnzjc3mFd+dIALj0WZC3Mq9NDmOYkPFDMtkAQAPfLA91Dr/8f6Tx2R427HMZg57S333tbSlSTTFQsdgQQAR6v8y5Es9T133plcRn0nMiAQR3ewmuvJXfO8id0CSQDQ1a0bb0pKUc+ef/9JQ3JZRj3jyGLvdLDS17PnX/OBPAMCSQDQndJiqF7u53OB0+CprBCII9tb7uvpefHGboEkAOhOPkmVVOOej0N+rF/ZgRw3BH5GOclopsZ9wbRAEgB0oaQQEoQnDZxOLwB+1nipjyD8OBmKeU1GAoCukdaSnpr2dyzZ/rz6VjAtEIdN13IqUen9tLwwpyilF4AEAB3PTEqKtP5/rhfglFG5gEKu13lz2lfJE4inqaZZSTwfJADo7Gy+R6f9HYvLBuo/eZhA9LgDlbxiBr4dITGSqvQCkACgg1v/3pSWIwLxDPpOHFKQo+u3V4XeaYLW/zPHJ8kwLZAEAJ0qLoQylvd65l4A5zR4OvsE9Kq9pT7RN3aUBoQOb4oEEgB0GB+l8jWm/R1LbrhPuUFGgPeaYpTRXMi0v2OJfKDE0wtAAoCOkhRrBGGRBk4fkRyFXC8ZL/cThEWqpLwmIwFAx0irsXxM5+ZiZfpy6lsxSCB6xGQ1xxa4SylPvFNILwAJADqAN8Ulpv0tuRfglGEFGQq5rq/MzOlAhVc+S1WNs+wWSAKAdpeUIynlSV0qlwnUfwq7BXa7/eW8YlqzS2aSarwKIAFAGz+kiT+cAGBZ+lYMKZPPEoguVUsDTdaY9nc88aNtQQKANkXX//F2A0gDp7FPQLfaW+qnG/s4VRN6AUgA0HZ8mMjXEgJxnHLDfcqNMEK828xHWc1HVF7H3cjwgWIWByIBQHthvf/6GTiVsQDdxOzwoj+oUy8AGyeRAKCNKv9yJJ8w7a9eMvms+k9in4BuMVHLqcZ6/3WTmlNIPEkA0AatG9b7b4j+k4cUZHk8Oj459k4HWPSn/r0ASUbGqwASALQ4Gy+FMs/IpnpzQaD+UxgQ2On2lfsYud6IhoekKr0AJABoHR97pZWY4q1B+lYMKNvPevGdqpIEmqpx/RolSgOl9AKQAKA1klIok3gCG4hpgZ1rvETXf6N7ASoxVQgJAJrf+q8l8iHT/hotO5hXfoyKpNPMhlkVGa3e+EaIBYo91QgJAJqaeifFMCUQTeoFOGWU3QI7KTmWtJeBf01TTYLD3QEgAUATsu5KJJ96mjfNekhyGQ2cPEQgOsShcp+ilIStWVJzqtELQAKAZjRvTEkpiglEc/WfNMy0wA4Q+UAHqwz8a7ZakvWeAYEkAGhw678QFmVGCddszjEgsAPsK/eJiqj5TBbUkoDXkiQAaJg4TdNazBJ1LZIfHVBmkNyrXZXjjGZq7ObYKpEPgpRXASQAaNADthAeYNpfaw2dNkYQ2tSeMuv9t7YXQK6cBFNEggQAdZZW4p0+Sc8gEq2V6c8pv2KQQLSZ6VpOZab9tb6cMndK6INxIkECgHq2/kvhHFFoDwOnjMgFdMS0UaWj/eU8gWgT1SQ7QRRIAFBHZz03u9LJbXByZaLR4ocmG2jgZLYMbhcHK3lFvHtuOedUVqAPZp+z4vVEo0OuGSHoLOOXXPJs76JrndkfMh6gdcxMhZ1T8hEDn1spTAM9OjfIznStrURMcrflg9xlf7z19v1EhAQADbb30gt+NU1so2S/SjRaIy7VVNrLm5lW2r4woLmIkf8tbPY/6Cz4n2u23/ldgkECgOa2Qt3e1edfbNKHzPRsItJ8xfEZJeWIQLQi9nFWT8wPEIjWVPwHnen9q7dt+oJzjoWAOxQvzjr6GXR25s1f+kLfCcELndM1ci4kKs01eNoY+wS0IvmVNF5i4F8LmoyhXPDnK/K5F67ZftfNVP70AKBN7F59wfOd2XVm9iai0TyVQwsK5yoEookma3ntKTLvv8kNjq9kXGbdJVvv2Ek0SADQpvauPv/c1LRRZr9MNJrQGvVeC9unZKknGE2QmvTI7LAST/HVpGriUZdx69Zs2fQNYtFdeAXQhc646dZvnvXbb3qVnHuXc5omIg0uHoNAA6cwLbBZ9pf7qfyb0+KfcS5Yu+KVuVdS+dMDgA40t+6iFcVC/GFzequZGC7dsG4AaWHXlHyYEIsGqqWBHpsdYvv5xtYKiZz7y6G+wfe95dEvM82FBACd7sClF70oTuIbTPq3RKMxknKo4vgsgWigrQsDWmDaXwMrBPcNOffONds2PU40SADQZXavOv93JX1KZi8kGvVX3jenqFgjEA0wH2W1bYFpfw2qCrbJufdcum3TPxCL3sEYgB7zvJtv/epZmcGXORdcLqcFIlJfA6eNyjEtsO7MpL0lRv03oAlYcAquXNGXexmVPz0A6CEH33XxKWE5/oRz+mMzIxmsk+pUQbVptmyop0OVvPay3W89i34fOH0xP+Auv/CRTZPEgwQAPWrfmotekfp4o5nYxKMerVVvKmyfkk/ZJ6AeEnN6ZGZIKev916fQd+5bzjJrV2+/43tEgwQAkCSNrz7/f3izj8l0FtE4PuFCRZUDvGGph13Ffk3XcgSiDo+4FFx16fZNXyIUkBgDgKc486Zb//asM3Ivci74oHOOpe2OQ9/YoDL9VFrHq5JkqPzrEEbn3IdWnJJ/EZU/6AHAMe1924XP8XF6rZn+kGgsT1KNVNw9QyCOwxPzgyrGGQKx7ALe3S4F71mz/c59RAMkAFiSfZdc+Gup/EaT/RuisXTl/fOKClUCsQyzYU47Cv0EYnkF+0OZrNZe8sTf3Uc0QAKAZTMzt2fNhZfI24clO52ILJ6PUy3smDo8jw2Lj5tJj80OK2TJ36UW6IcsCP50zZY7b2KnPhwLYwBw7ELFOXveTbfcPNg/+oLAuT9n2+ElPGC5jAZOGiYQS3Sw0kflv7RnNHJy1waZk1546dZNn6fyBz0AaIg9b7/kFxRF15nZ7xONRTDTwo4p+ZhpgYsRpU6Pzg3JM+1vsaX4V/Pm1l60/a4dBAMkAGhOIrDqLW+U3HVm9jKicYxKrVBTeT/7qizGjkK/ZkNG/i+i8P5hJsiuu2TrHf+PaGA5eAWAZTvr5i/945m//aZXuCBY6+QY7n4U+dF+ZQfzBOIYSkmGyv9YFb9zs4Fz68ZemX85lT/oAUDrewPe/vYTLCp+2MkuZdvhI0trsQq7pgnEUfxoblDlhGl/Ry6sXSpnn3f5/NWrf3g7206CBABtlgi89S0vUeI+bWb/jmj8vMrBBYXzrLF0JNO1nHYVmfb3DCX1/1Muu+7SH93xQ4IBEgC0tfFV5/8nkz5pZmcTjZ/yaarC9imZZ5D2U6Xm9OjskGJG/j+thHY7nNz6Nds23UkwUG+MAUBDnHnzrXedecbZL3WBrpRcgYg8+cBlMuo/mWmBT3egkqfy/5l6X8UgcFetyOdeQuUPegDQsSZWrz6tZtWPS+5Cth2WzEwFpgX+RPjktD9j2p+cZJJuUf/g+jWP/e0EdwdIANAVdl96/qtcoo0me12vxyIuhSrtZRyXJG1bGNB8xLhRJ31bWbd2zRN3beauAAkAujMRuOT8tzjZx0w6o5fjUBqfUVyOevpeKMQZbZkf7PFC2O2VdNWa7XfdSumAZmIMAJrueV+49UvB2KnnBHIf6uVthwdPG+vpFNwkjff0qH9XdU4fOX3s1BdR+YMeAPSc/e+4+IwkjK81szf34vlXJgoKZ8s9ee0nq3ntKfX1ZsHr9H/68vnLLvzh7eOUAiABQE/bs+qPf0NKNprpV3qqFZx6LeyYkqW+p653ak6PzA4p6bmR/+7hTODWrtq66V956tFqvAJAWzjr5r/59plnvOA1TsGlcuqZ0c8uE2jglJGeu977Svkeq/zdpAvcW9ec/4p/Q+UPegCAZzB1ySUjZYUfkPQuSd2/gL6ZCrumlYZJT1zfapLRD+cG1QtLITnnInP2mUE/vOH87V9iPQyQAACLsXfV+Wd76Toz+91uP9ekHKk43hv7KW1dGNBCD0z7c859LZvNrLv48Tu28TSDBABYhj2rz/8teV1nspd083mW980pKta6+lrORVltXxjo9or/8cC0btX2u77O04t2xhgAtL2zbrr1/5555tkvd86tc05du3rOwKkjcq57c3IzaV93j/qfCxS85+znvOKXqfxBDwBQZ3tXrTrRu9pH5LXGpK7bN7Y6WVRtptSV1+5gJa995e5LAJxcas7d1JfR1X/8xKYZnlKQAAANNL7qgpeZ+U+b9G+7qpXsTYUdk/JJd00LjH2gR+cGlXbZyH8n941s1tZd/MTfPcpTCRIAoJk9Aqsv+ANvdo2Z/WK3nFO0UFX5wHxXXaddxX5N13LdU3A6tzOQ1q/adtcdPIXoVIwBQEc746Zb7jzzjLNf4lxwlZwrdsM55ccGlBnonsqykmS6p/J3ruRc8L7n2BkvofIHPQBAm5h8x0WnV2vJJyS7wDr83k6qkYq7u+N18uPzgyrFnT1cw0lmcrcO5ILLL3j8zoM8bSABANrQ+CUXvNpkG0326518HuUD84oWqh19LWbCrHYWOnvan5P7TjYI1l689c4HebpAAgB0gD2r33K+zH3MzJ7bicfvE6+F7ZOH58914vGb9OjssKJOHfjntN+54KrVW+68xTlnPFHoNowBQNc666Yv3ZrLDJ4jF3zESR3XlA6ygQZOHu7Y+B+s5juy8ndSzSn4aP/A6Dlrtm76IpU/6AEAOtiBSy88M078tSb7rx114GZa2DElH6cdddiRd3p0dli+w6pO59ydLhu8Z/Xjd+7hqQEJANBFxlef/5vetFFmr+yUY44LNZX2z3VUnHcUBjQbds56/86572fMrbtk+6Z/5ilBr+AVAHrKmTfd+q2zzjj71S4I3iq5yU445txov7KDnbMpYinOdEzl75ybkgvevvotr/gVKn/QAwD0iJl3vWW0WHEbJL1TZm09UT2pxSrumu6IuP5obkjlpM3bFs7FTvrM2Ghuw3/bfPsCTwNIAIAetPetF70gTZLrZPYf2vk4K4cWFM5V2jqWU7Wcdhf7273QuyfI5Net2nL7Fu5+kAAA0PiaC37be/u0zF7cjsfnE6/CjimZb899AlLv9OjcoGLfpq1/pycyzr1n1da77uZuBxgDAPzEmZ+/5d6zzjj7lwMXvEdybbcYf5AN1H9K+04LPFDpa8vK38nNKwgue9Xoab9M5Q/QAwAc1b4/ufCktOY/IrPV7bbtcGHHlNIoaat41dJAj80NtdWaRU4udbIvDAaDV/3R1r+d5q4GSACARdt76UW/lKbxRplWtssxxaVQpb2zbRWnbQsDmo/aZ+S/k/tmELh1q7Zu+gF3MUACACzb7kvO/y/O6ZNm9vx2OJ7S+KzictgWsVmIstq60Cbr/Tu3OzC3fvX2Tbdz1wJHxxgAYBGe94Vb7zhz8IQXB4He55xKrT6egdNG2yJ9N0l7y61fo8A5leXc+3PPWfFiKn+AHgCgMb0Bl57/LJfaJ2Q6v5XbDlcnCqrNllsai4lqXuOlvlYWYCanLwfBwPpVW/7XAe5OgAQAaLi9qy58TSq/UWavbcX3+9RU2DEpS1szLTDxTo/MDim1FhUjTvdnlV17ybY77uduBEgAgKYyMze+5oIL5PVRkz2n2d8fzldUOdiahez2lPo1WW3+AorO6YBzwVWrttzJTn3AcWAMAHBclZGzs2669Yt9J7pzFLiPSq7WzO/vGxtQpq/5lXA1DTTV7MrfKXSBPj6Wz5+zeuumv6HyB+gBANrGwbdd9Lwwjq+V6Q+a9Z1xJVRpT3OnBW6ZH1Qhbt7yCM5pk4L8ZWu23L6LuwwgAQDa1t41F7whTW2jZC9vxveV9s0pLjan82EuzGl7oTnr/TunR4Igs27Vljv/ibsKqC9eAQANcMbnb/nns848+1WBgrdLbqrR3zd42qica3w+b+a0t9yEUf9O007uHWOvyL+Kyh+gBwDoSLOXXjpWTKobzNmfNHLb4dpUUdXpxi5RcLCS175GJgBOiZM+mx1yH7j4+3fNc/cAJABAx9t/yfnnxE7Xyex3GtI696aFHVOyJG3I8cfe6dEGTvtz0j3ZIPvui7fe8QR3C0ACAHSdvWsu/Pep95+W2Tn1/uxooarygcY0nHcV+zVdq38HhpPbas5ddum2Tf/A3QE0D2MAgCY74/NfvPuszOAvBXKXyamuk/jzYwPKDtS/ki4nmQZU/m4hcHrvK8dOfRmVP0APANBTDr7r4lOiSvQRya0ys7ok5Ek1VnF3fXe/fXxuSKWkXu0F553cF/oGdfWFj2ya5C4ASACAnrXvree/PIm1UbI31KXFfmBe0UK1Lsc2U8tpZ7E+0/6c07+Y3NpLt931fa46QAIA4El7Vl3wZjN/jaTnHc/nWJIeHhDoj2+xPG9Oj84NKUqPr6hwcnsso/WXbrnrNq4y0B4YAwC0kbNuvuX2s87MvVgueL+TW/ZWfy6bUf/Jw8d9PAcr+eOt/CuBgg9kn7viRVT+AD0AABZh79sufI5P/Cfk7Y+Wte2wlxV2Tro0Xt60wNA7/XB22FJbXjnhnPuyLLh8zfY793E1ARIAAEu0b/VbXpuaNprpNUv927hYU2nf3LK+d0dhQLNhdjk1/4OZjFu76olN3+HqASQAAI6Dmbnx1edfKLmPmdmzlvK3pT0ziivRkr6vGGf0xPzgUguTQ3LBVau33vnX7NQHtD/GAACdkKk7Z2fd/KW/GegbfaFT8HE5Fy72bwdPH/Na4j4Be0t9i6/AncIgCD4RZE564Zptm/6Kyh+gBwBAg+xefcHz5e1ayf7zYn6/crCgcH5xYwqnajntXuS0Pyf3d5kg855Ltt6xk6sCkAAAaF4icJ7z/jqTfulov2fe4sL2iZxPj944T83pkdnhOPHKHaPif8wFWrd6613/yFUAOhOvAIAO9rybbvnGmb/zH18ZBO4dTm7mGSvswOX6Tx5NjvV5Byp96dEqf+fcjAuCd469MvcKKn+AHgAAbWDP299+gsLCBjm9w0xHGr6fFnZOZdLwyHlALQ302OxQalLmCCVF4uT+YrB/8ANvefTLc0QbIAEA0GYOrL7gxbH3nzbpt38uA6hEc4U9Mycc6e+2zA8sFOLs2BGa/V/PWu7dl2y//UdEFyABANDuPQJrLvw9pemnTHrBU39e3jcXRcVa/qk/W4izydb5gezTCoftQSZz2aotd/490QS6D2MAgC511ue/+A9nZodeKufeK7nCj38++OwV80/9PZO0q9A/95Sav+BcsH6sL/9SKn+AHgAAHezQ2y44NYztI5IuMbMgnCrtqUwXz5Kkg5W+ffvK+edKzsvpr13fwFVrHvvbCaIGkAAA6BL7V134ykR+ozd7RXH7RC4OFXxvZqjmnXskmw3WXvL4nQ8TJYAEAECX2rPm/P8Wz9cufuTxamY2yn9h9dZN/4uoAADQA+yii/rve+6bB4gEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABL9f8DO8d7iun3N5gAAAAASUVORK5CYII=
+    mediatype: image/png
+  keywords: []
+  links:
+  - name: GitHub
+    url: https://github.com/CleverCloud/clever-kubernetes-operator
+  - name: Clever Cloud
+    url: https://www.clever-cloud.com
+  maintainers:
+  - email: florentin.dubois@clever-cloud.com
+    name: Florentin Dubois
+  maturity: alpha
+  provider:
+    name: Clever Cloud
+  version: 0.8.0
+  relatedImages:
+  - name: clever-kubernetes-operator
+    image: docker.io/clevercloud/clever-kubernetes-operator:3e427f3bb10071bd95811ba74a6a71bd247a8fb7
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: PostgreSql
+      name: postgresqls.api.clever-cloud.com
+      version: v1
+      displayName: PostgreSql
+      description: Clever Cloud's managed postgresql database
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Plan of the instance used to spawn the database
+        displayName: Plan
+        path: instance.plan
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Options of the database
+        displayName: options
+        path: options
+      - description: Should the disk be encrypted?
+        displayName: Encryption
+        path: options.encryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Version of the database
+        displayName: Version
+        path: options.version
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: Redis
+      name: redis.api.clever-cloud.com
+      version: v1
+      displayName: Redis
+      description: Clever Cloud's managed redis database
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Plan of the instance used to spawn the database
+        displayName: Plan
+        path: instance.plan
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Options of the database
+        displayName: options
+        path: options
+      - description: Should the disk be encrypted?
+        displayName: Encryption
+        path: options.encryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Version of the database
+        displayName: Version
+        path: options.version
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: MySql
+      name: mysqls.api.clever-cloud.com
+      version: v1
+      displayName: MySql
+      description: Clever Cloud's managed mysql database
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Plan of the instance used to spawn the database
+        displayName: Plan
+        path: instance.plan
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Options of the database
+        displayName: options
+        path: options
+      - description: Should the disk be encrypted?
+        displayName: Encryption
+        path: options.encryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Version of the database
+        displayName: Version
+        path: options.version
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: MongoDb
+      name: mongodbs.api.clever-cloud.com
+      version: v1
+      displayName: MongoDb
+      description: Clever Cloud's managed mongodb database
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Plan of the instance used to spawn the database
+        displayName: Plan
+        path: instance.plan
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Options of the database
+        displayName: options
+        path: options
+      - description: Should the disk be encrypted?
+        displayName: Encryption
+        path: options.encryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Version of the database
+        displayName: Version
+        path: options.version
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: Pulsar
+      name: pulsars.api.clever-cloud.com
+      version: v1beta1
+      displayName: Pulsar
+      description: Clever Cloud's managed pulsar messaging system
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: ConfigProvider
+      name: configproviders.api.clever-cloud.com
+      version: v1
+      displayName: ConfigProvider
+      description: Clever Cloud's configuration provider addon
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Key-Value of environment variables to expose
+        displayName: Variables
+        path: variables
+        x-descriptios:
+        - urn:ulm:descriptor:object
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: ElasticSearch
+      name: elasticsearches.api.clever-cloud.com
+      version: v1
+      displayName: ElasticSearch
+      description: Clever Cloud's managed elasticsearch indexes
+      resources:
+      - kind: Secret
+        version: v1
+      specDescriptors:
+      - description: Instance options
+        displayName: Instance
+        path: instance
+      - description: Plan of the instance used to spawn the database
+        displayName: Plan
+        path: instance.plan
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Region of the instance used to spawn the database
+        displayName: Region
+        path: instance.region
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Options of the database
+        displayName: options
+        path: options
+      - description: Should the disk be encrypted?
+        displayName: Encryption
+        path: options.encryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Version of the database
+        displayName: Version
+        path: options.version
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Deploy a kibana addon as well?
+        displayName: kibana
+        path: options.kibana
+      - description: Deploy apm server addon as well?
+        displayName: apm
+        path: options.apm
+      - description: Clever Cloud's organisation to spawn the database
+        displayName: Organisation
+        path: organisation
+        x-descriptors:
+        - urn:alm:descriptor:text
+      statusDescriptors:
+      - description: Clever Cloud's addon identifier
+        displayName: Addon
+        path: addon
+        x-descriptors:
+        - urn:alm:descriptor:text
+    - kind: KV
+      name: kvs.api.clever-cloud.com
+      version: v1alpha1
+      displayName: Pulsar
+      description: Clever Cloud's mmateria key-value store
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the database
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the database
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Azimutt
+      name: azimutts.api.clever-cloud.com
+      version: v1
+      displayName: Azimutt
+      description: Clever Cloud's azimutt integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Cellar
+      name: cellars.api.clever-cloud.com
+      version: v1
+      displayName: Cellar
+      description: Clever Cloud's cellar integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's cellar URL
+          displayName: URL
+          path: url
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Keycloak
+      name: keycloaks.api.clever-cloud.com
+      version: v1
+      displayName: Keycloak
+      description: Clever Cloud's keycloak integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's keycloak URL
+          displayName: URL
+          path: url
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's keycloak admin URL
+          displayName: Admin URL
+          path: admin_url
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Matomo
+      name: matomos.api.clever-cloud.com
+      version: v1
+      displayName: Matomo
+      description: Clever Cloud's matomo integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's matomo URL
+          displayName: URL
+          path: url
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Metabase
+      name: metabases.api.clever-cloud.com
+      version: v1
+      displayName: Metabase
+      description: Clever Cloud's metabase integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's metabase URL
+          displayName: URL
+          path: url
+          x-descriptors:
+            - urn:alm:descriptor:text
+    - kind: Otoroshi
+      name: otoroshis.api.clever-cloud.com
+      version: v1
+      displayName: Otoroshi
+      description: Clever Cloud's otoroshi integration
+      resources:
+        - kind: Secret
+          version: v1
+      specDescriptors:
+        - description: Instance options
+          displayName: Instance
+          path: instance
+        - description: Region of the instance used to spawn the service
+          displayName: Region
+          path: instance.region
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Plan of the instance used to spawn the service
+          displayName: Plan
+          path: instance.plan
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's organisation to spawn the service
+          displayName: Organisation
+          path: organisation
+          x-descriptors:
+            - urn:alm:descriptor:text
+      statusDescriptors:
+        - description: Clever Cloud's addon identifier
+          displayName: Addon
+          path: addon
+          x-descriptors:
+            - urn:alm:descriptor:text
+        - description: Clever Cloud's otoroshi URL
+          displayName: URL
+          path: url
+          x-descriptors:
+            - urn:alm:descriptor:text
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  install:
+    strategy: deployment
+    permissions:
+    - serviceAccountName: clever-kubernetes-operator
+      rules:
+      - apiGroups: [""]
+        resources: ["secrets", "events"]
+        verbs: ["*"]
+      - apiGroups: ["api.clever-cloud.com"]
+        resources: ["*"]
+        verbs: ["*"]
+    spec:
+      deployments:
+      - name: clever-kubernetes-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: clever-kubernetes-operator
+          template:
+            metadata:
+              labels:
+                app: clever-kubernetes-operator
+            spec:
+              containers:
+                - image: docker.io/clevercloud/clever-kubernetes-operator:3e427f3bb10071bd95811ba74a6a71bd247a8fb7
+                  imagePullPolicy: Always
+                  name: clever-kubernetes-operator
+                  command: ["/usr/local/bin/clever-kubernetes-operator"]
+                  args: ["-vvvvvvv"]
+                  resources:
+                    requests:
+                      memory: 64M
+                      cpu: 100m
+                      ephemeral-storage: 128Mi
+                    limits:
+                      memory: 64M
+                      cpu: 100m
+                      ephemeral-storage: 128Mi
+                  ports:
+                    - containerPort: 8000
+                      protocol: TCP
+                      name: observability
+                  livenessProbe:
+                    failureThreshold: 3
+                    httpGet:
+                      path: /metrics
+                      port: observability
+                      scheme: HTTP
+                    periodSeconds: 30
+                    successThreshold: 1
+                    timeoutSeconds: 1
+                  readinessProbe:
+                    failureThreshold: 3
+                    httpGet:
+                      path: /healthz
+                      port: observability
+                      scheme: HTTP
+                    periodSeconds: 5
+                    successThreshold: 1
+                    timeoutSeconds: 1
+                  securityContext:
+                    readOnlyRootFilesystem: true
+                    allowPrivilegeEscalation: false
+                    runAsNonRoot: true
+                    runAsGroup: 25000
+                    runAsUser: 20000
+              restartPolicy: Always
+              terminationGracePeriodSeconds: 30

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/metadata/annotations.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/metadata/annotations.yaml
@@ -1,0 +1,13 @@
+---
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "clever-kubernetes-operator"
+  operators.operatorframework.io.bundle.channels.v1: "alpha"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"
+  operators.operatorframework.io.test.mediatype.v1: "scorecard+v1"
+  operators.operatorframework.io.test.config.v1: "tests/scorecard/"
+  com.redhat.openshift.versions: "v4.6-v4.12"
+  com.redhat.delivery.operator.bundle: "true"
+  com.redhat.delivery.backport: "true"

--- a/deployments/operator-lifecycle-manager/bundle-0.8.0/tests/scorecard/config.yaml
+++ b/deployments/operator-lifecycle-manager/bundle-0.8.0/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.39.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
  Packages the dependency and add-on updates from #160.

  * Kubernetes stack: kube 0.99 → 3.1, k8s-openapi v1_30 → v1_35, schemars 0.8 → 1.x
  * clever-cloud SDK 0.15 → 1.0.1; MSRV raised to 1.91
  * Add-on versions aligned with the catalog: PostgreSQL 18, Redis 8.8.0, Elasticsearch 9, MySQL 8.4
  * Refresh the OLM bundle (bundle-0.8.0) and the Helm CRD bundle
  * CI: don't push Docker images on pull requests (#150); point the OperatorHub bundle job at bundle-0.8.0