### PR TITLE
fix(deploy): align observability port to 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Environment variables are:
 
 | Name                                  | Kind            | Default                        | Required | Description                                                       |
 | ------------------------------------- | --------------- | ------------------------------ |----------|-------------------------------------------------------------------|
-| `CLEVER_OPERATOR_OPERATOR_LISTEN`     | `SocketAddress` | `0.0.0.0:7080`                 | yes      |                                                                   |
+| `CLEVER_OPERATOR_OPERATOR_LISTEN`     | `SocketAddress` | `0.0.0.0:8000`                 | yes      |                                                                   |
 | `CLEVER_OPERATOR_API_SECRET`          | `String`        | none                           | false    |                                                                   |
 | `CLEVER_OPERATOR_API_TOKEN`           | `String`        | none                           | yes      | if used alone, we assume that we are using oauthless auth backend |
 | `CLEVER_OPERATOR_API_CONSUMER_KEY`    | `String`        | none                           | false    |                                                                   |

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -18,4 +18,4 @@ consumer-secret = ""
 #
 # For the moment, only the listen port is available.
 [operator]
-listen = "0.0.0.0:8080"
+listen = "0.0.0.0:8000"

--- a/deployments/kubernetes/v1.30.0/20-deployment.yaml
+++ b/deployments/kubernetes/v1.30.0/20-deployment.yaml
@@ -139,7 +139,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '8080'
+        prometheus.io/port: '8000'
       labels:
         app: clever-kubernetes-operator
     spec:
@@ -169,7 +169,7 @@ spec:
               cpu: 100m
               ephemeral-storage: 128Mi
           ports:
-            - containerPort: 8080
+            - containerPort: 8000
               protocol: TCP
               name: observability
           readinessProbe:


### PR DESCRIPTION
## Problem

The operator listens on `0.0.0.0:8000` by default (`src/svc/cfg.rs`), and the Helm chart
(`deployments/kubernetes/helm`) already uses `8000`. But the shipped raw manifest
`deployments/kubernetes/v1.30.0/20-deployment.yaml` exposed and probed port **8080**, so the
`readinessProbe` (which targets the `observability` port) never succeeds and the pod never
becomes Ready. On top of that, the README documented **7080** and `config.sample.toml` used
**8080** — three different values in circulation.

## Change

Align every port reference to **8000**:

- `deployments/kubernetes/v1.30.0/20-deployment.yaml`: `containerPort` and
  `prometheus.io/port` `8080` → `8000`
- `config.sample.toml`: `listen` `8080` → `8000`
- `README.md`: documented default `7080` → `8000`

The operator serves `/healthz`, `/livez`, `/readyz`, `/status` (and `/metrics`) on that port
(`src/svc/http/server.rs`), so the readiness probe now hits a live endpoint.

## Notes

- The frozen OLM bundles under `deployments/operator-lifecycle-manager/bundle-*` are left
  untouched (historical, versioned artifacts).
- No code change, so no unit test applies. A future CI guard (manifest lint, or an e2e
  deploy-and-wait-for-Ready) could prevent this class of drift.

Closes #162
