### PR TITLE
chore(docker): pin base image and respect pinned toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
-FROM redhat/ubi9:latest AS builder
+FROM redhat/ubi9:9.8@sha256:46d19c10caf9888e8a01131283eaaf50c7f5d4eddab02cd92a66f8adf2e15407 AS builder
 
 WORKDIR /usr/src/clever-kubernetes-operator
 ADD src src
 ADD Cargo.toml .
 ADD Cargo.lock .
+ADD rust-toolchain .
 
 RUN dnf update -y && dnf install gcc openssl-devel -y
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --verbose -y \
     && export PATH="$HOME/.cargo/bin:$PATH" \
     && cargo build --release
 
-FROM redhat/ubi9:latest
+FROM redhat/ubi9:9.8@sha256:46d19c10caf9888e8a01131283eaaf50c7f5d4eddab02cd92a66f8adf2e15407
 
 LABEL name="clever-kubernetes-operator" \
     maintainer="Florentin Dubois <florentin.dubois@clever-cloud.com>" \
     vendor="Clever Cloud S.A.S" \
-    version="v0.6.0" \
+    version="0.8.0" \
     release="1" \
     summary="A kubernetes operator that expose clever cloud's resources through custom resource definition" \
     description="A kubernetes operator that expose clever cloud's resources through custom resource definition"


### PR DESCRIPTION
## Problem

The Dockerfile (#157):
- used a **floating** `redhat/ubi9:latest` base image (non-reproducible builds);
- installed the **default stable** Rust toolchain via rustup, **ignoring the repo's pinned
  `rust-toolchain`** (1.91.0) — the file was never copied into the build context;
- carried a **stale version label** (`v0.6.0`, while `Cargo.toml` is `0.8.0`).

## Change

- Pin **both** build stages to `redhat/ubi9:9.8` **by digest**
  (`sha256:46d19c10…15407`).
- `ADD rust-toolchain .` into the build context so rustup builds with the pinned **1.91.0**.
- Update the image `version` label to **0.8.0** (matches `Cargo.toml`).

## Notes

- Digest resolved from Docker Hub `redhat/ubi9:9.8` at authoring time; bump it when moving to a
  newer UBI9.
- Follow-up idea (not in this PR): pass the version label via a build `ARG` derived from
  `Cargo.toml` to avoid it drifting again.

Closes #157
