### PR TITLE
chore(deploy): drop all capabilities and set seccomp RuntimeDefault

### DIFF
--- a/deployments/kubernetes/helm/values.yaml
+++ b/deployments/kubernetes/helm/values.yaml
@@ -40,6 +40,11 @@ securityContext:
   runAsNonRoot: true
   runAsGroup: 25000
   runAsUser: 20000
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 resources:
   requests:

--- a/deployments/kubernetes/v1.30.0/20-deployment.yaml
+++ b/deployments/kubernetes/v1.30.0/20-deployment.yaml
@@ -187,5 +187,10 @@ spec:
             runAsNonRoot: true
             runAsGroup: 25000
             runAsUser: 20000
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Change

Harden the pod container `securityContext` (part of #155):
- drop **ALL** Linux capabilities (`capabilities.drop: [ALL]`);
- set `seccompProfile.type: RuntimeDefault`.

Applied in both deployment paths:
- `deployments/kubernetes/v1.30.0/20-deployment.yaml`
- `deployments/kubernetes/helm/values.yaml`

The existing hardening (`readOnlyRootFilesystem`, `runAsNonRoot`,
`allowPrivilegeEscalation: false`, fixed uid/gid) is kept.

## Scope note

This PR intentionally covers **only** the pod securityContext part of #155. The other items
of #155 — narrowing the cluster-wide secret RBAC and removing the OLM wildcard permissions —
are **deferred**: they depend on which namespaces the operator actually reconciles and are best
done alongside the per-module RBAC work (least-privilege per activated module). Tracking them
separately avoids a risky RBAC change bundled into a safe hardening PR.

Refs #155
