### PR TITLE
fix(security): redact secrets from tracing spans

### DIFF
--- a/src/svc/clevercloud/client.rs
+++ b/src/svc/clevercloud/client.rs
@@ -62,7 +62,7 @@ impl From<cfg::Error> for Error {
 // -----------------------------------------------------------------------------
 // helpers
 
-#[cfg_attr(feature = "tracing", tracing::instrument)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(secret)))]
 pub async fn try_from(secret: Secret) -> Result<Client, Error> {
     let buf = blocking(move || {
         let (namespace, name) = resource::namespaced_name(&secret);

--- a/src/svc/k8s/secret.rs
+++ b/src/svc/k8s/secret.rs
@@ -25,7 +25,7 @@ where
     format!("{}-secrets", obj.name_any())
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument)]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(secrets)))]
 pub fn new<T>(obj: &T, secrets: BTreeMap<String, String>) -> Secret
 where
     T: Resource<Scope = NamespaceResourceScope> + ResourceExt + CustomResourceExt + Debug,


### PR DESCRIPTION
## Problem

`#[tracing::instrument]` records every function argument via its `Debug` impl as span fields.
Two secret-bearing functions were instrumented **without skipping** their sensitive arguments,
so credential material could be written to logs / a tracing backend whenever span fields are
captured (#154):

- `src/svc/k8s/secret.rs::new` — the `secrets: BTreeMap<String, String>` holds plaintext
  secret values.
- `src/svc/clevercloud/client.rs::try_from` — the `Secret` carries the base64-encoded Clever
  Cloud API credentials.

## Change

Add `skip(...)` to those two `instrument` attributes:
- `secret.rs::new` → `tracing::instrument(skip(secrets))`
- `client.rs::try_from` → `tracing::instrument(skip(secret))`

This matches the `skip_all` pattern already used in `src/svc/http/layer.rs`. The non-sensitive
arguments (e.g. `obj`) are kept in the span for observability. Other instrumented functions in
these files (`secret::name`, the `From<…>` impls) take no secrets and are left unchanged.

Closes #154
