### PR TITLE
fix(addon): look up addon by name even when id is not yet persisted

### DIFF
--- a/src/svc/clevercloud/ext.rs
+++ b/src/svc/clevercloud/ext.rs
@@ -55,18 +55,13 @@ pub trait AddonExt: Into<CreateOpts> + Clone + Debug + Sync + Send {
                     Err(Error::Get(_, _, ClientError::StatusCode(code, _)))
                         if StatusCode::NOT_FOUND.as_u16() == code.as_u16() =>
                     {
-                        // try to retrieve the addon from the name
+                        // The stored identifier no longer exists upstream; fall through to
+                        // the name-based lookup below.
                         trace!(
                             id = &id,
                             name = self.name(),
-                            "Trying to retrieve the addon by name for the addon",
+                            "Addon not found by identifier, falling back to name lookup",
                         );
-
-                        return Ok(addon::list(client, &self.organisation())
-                            .await?
-                            .iter()
-                            .find(|addon| addon.name == Some(self.name()))
-                            .map(ToOwned::to_owned));
                     }
                     Err(err) => {
                         return Err(err.into());
@@ -74,8 +69,16 @@ pub trait AddonExt: Into<CreateOpts> + Clone + Debug + Sync + Send {
                 }
             }
 
-            trace!("No such identifier to retrieve addon '{}'", self.name());
-            Ok(None)
+            // Name-based lookup using the deterministic addon name
+            // (`kubernetes::<Kind>::<uid>`). This also runs when no identifier has been
+            // persisted to the CR status yet, which prevents creating a duplicate addon when a
+            // reconcile retries (or another pod reconciles) before the id is saved (#163).
+            trace!(name = self.name(), "Retrieve the addon by name");
+            Ok(addon::list(client, &self.organisation())
+                .await?
+                .iter()
+                .find(|addon| addon.name == Some(self.name()))
+                .map(ToOwned::to_owned))
         }
     }
 


### PR DESCRIPTION
## Problem (#163)

`AddonExt::get` (`src/svc/clevercloud/ext.rs`) returned `Ok(None)` immediately when the CR
`status` held no addon id, so `upsert` then created a new addon. If a reconcile retried — or
another operator pod reconciled — **after** the addon was created upstream but **before** its
id was persisted to `status`, a **second, untracked, billable** addon was created with the same
name. On CR deletion only the tracked addon was deprovisioned, leaving the duplicate orphaned.

The deterministic addon name (`kubernetes::<Kind>::<uid>`) already uniquely ties an addon to
its CR, but the name-based lookup only ran as a 404 fallback of the "id present" path — never
when the id was still absent.

## Change

Run the name-based lookup **unconditionally**:
- when an id is set and `GET /addons/{id}` returns 404, fall through (instead of returning) to
  the name lookup;
- when no id is set, go straight to the name lookup instead of returning `Ok(None)`.

So an already-created addon is found and reused instead of being duplicated.

## Scope / follow-up

This closes the **single-process** window. Two **concurrent** reconciles can still both find
nothing and both create. Full protection needs leader election + an in-process reconcile mutex
— tracked separately (part of the operators-merge concurrency work).

Closes #163
