### PR TITLE
chore(helm): store API credentials in a Secret instead of a ConfigMap

### DIFF
--- a/deployments/kubernetes/helm/templates/deployment.yaml
+++ b/deployments/kubernetes/helm/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
       automountServiceAccountToken: true
       volumes:
       - name: config
-        configMap:
-          name: clever-kubernetes-operator-configuration
+        secret:
+          secretName: clever-kubernetes-operator-configuration
           items:
           - key: "config.toml"
             path: "config.toml"

--- a/deployments/kubernetes/helm/templates/secret.yaml
+++ b/deployments/kubernetes/helm/templates/secret.yaml
@@ -1,10 +1,11 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
 {{ include "cleveroperator.namespace" . | indent 2 }}
   name: clever-kubernetes-operator-configuration
-data:
+type: Opaque
+stringData:
   config.toml: |
     [api]
     token = "{{ .Values.config.token }}"


### PR DESCRIPTION
## Problem

The Helm chart rendered the Clever Cloud API credentials (`token`, `secret`, consumer
key/secret) into a **ConfigMap** (`templates/configmap.yaml`). ConfigMaps are not meant for
sensitive data and are more exposed (no RBAC distinction, shown in plain `get configmap`, etc.)
than Secrets. The shipped raw manifest (`deployments/kubernetes/v1.30.0`) already uses a
Secret — this aligns the chart with it (#156).

## Change

- Replace `templates/configmap.yaml` with `templates/secret.yaml`
  (`kind: Secret`, `type: Opaque`, same `config.toml` content via `stringData`).
- Mount the config volume from the Secret instead of the ConfigMap in `deployment.yaml`.

## Out-of-scope observation (NOT changed here)

The `config.toml` rendered by the chart uses `consumerKey` / `consumerSecret` (camelCase),
whereas the documented/sample TOML uses `consumer-key` / `consumer-secret`. If the operator's
config parser expects the hyphenated keys, the consumer credentials from the chart may be
ignored — a **separate potential auth bug**, worth its own fix/PR. Left untouched here to keep
this PR single-topic (ConfigMap → Secret only).

Closes #156
