### PR TITLE
refactor(daemon): run controllers through a core registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clever-kubernetes-operator-core",
  "clevercloud-sdk",
  "config",
  "futures",
@@ -396,6 +397,10 @@ dependencies = [
 [[package]]
 name = "clever-kubernetes-operator-core"
 version = "0.8.0"
+dependencies = [
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "clevercloud-sdk"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,3 +9,5 @@ license-file.workspace = true
 repository.workspace = true
 
 [dependencies]
+tokio = { version = "^1.44.0", features = ["rt"] }
+tracing = "^0.1.41"

--- a/crates/core/src/controller.rs
+++ b/crates/core/src/controller.rs
@@ -1,0 +1,57 @@
+//! # Controller
+//!
+//! A uniform abstraction over the operator's custom-resource controllers, so
+//! the daemon can run an arbitrary, dynamically-built set of them rather than a
+//! hardcoded list.
+
+use std::{future::Future, pin::Pin};
+
+/// A type-erased error returned by a controller.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The future driving a controller until it stops or errors.
+pub type ControllerFuture = Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send>>;
+
+/// A long-running controller that watches and reconciles a custom resource.
+///
+/// Each module provides one so the [`crate::registry::Registry`] can run them
+/// uniformly.
+pub trait Controller: Send + 'static {
+    /// Human-readable kind, used for logging (e.g. `"PostgreSql"`).
+    fn kind(&self) -> &'static str;
+
+    /// Consume the controller and return the future driving its watch loop.
+    fn run(self: Box<Self>) -> ControllerFuture;
+}
+
+/// A [`Controller`] backed by an already-built future.
+///
+/// It is the bridge used to wrap the existing reconcilers' `watch` loops as
+/// controllers without changing them.
+pub struct FutureController {
+    kind: &'static str,
+    future: ControllerFuture,
+}
+
+impl FutureController {
+    /// Build a boxed controller from a kind and the future of its watch loop.
+    pub fn boxed(
+        kind: &'static str,
+        future: impl Future<Output = Result<(), BoxError>> + Send + 'static,
+    ) -> Box<dyn Controller> {
+        Box::new(Self {
+            kind,
+            future: Box::pin(future),
+        })
+    }
+}
+
+impl Controller for FutureController {
+    fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    fn run(self: Box<Self>) -> ControllerFuture {
+        self.future
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,7 +2,13 @@
 //!
 //! Shared building blocks for the Clever Cloud Kubernetes operator.
 //!
-//! This crate is meant to host the code reused across the operator: the
-//! controller runtime/registry, leader election, Kubernetes primitives and the
-//! Clever Cloud client wiring. It is intentionally minimal for now and is
-//! populated incrementally as the operator is refactored onto a common core.
+//! For now this crate hosts the controller abstraction ([`Controller`]) and the
+//! [`Registry`] used by the operator daemon to run a dynamic set of controllers.
+//! It will grow with leader election, Kubernetes primitives and Clever Cloud
+//! client wiring as the operator is refactored onto a common core.
+
+pub mod controller;
+pub mod registry;
+
+pub use controller::{BoxError, Controller, ControllerFuture, FutureController};
+pub use registry::Registry;

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -1,0 +1,60 @@
+//! # Registry
+//!
+//! Holds the set of [`Controller`]s to run and starts them. This replaces the
+//! daemon's hardcoded `tokio::select!`: controllers are added dynamically (so a
+//! future configuration can enable only a subset) and run concurrently.
+
+use tokio::task::JoinSet;
+use tracing::info;
+
+use crate::controller::{BoxError, Controller};
+
+/// A set of controllers to run together.
+#[derive(Default)]
+pub struct Registry {
+    controllers: Vec<Box<dyn Controller>>,
+}
+
+impl Registry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a controller to the registry.
+    pub fn register(&mut self, controller: Box<dyn Controller>) -> &mut Self {
+        self.controllers.push(controller);
+        self
+    }
+
+    /// Number of registered controllers.
+    pub fn len(&self) -> usize {
+        self.controllers.len()
+    }
+
+    /// Whether the registry has no controller.
+    pub fn is_empty(&self) -> bool {
+        self.controllers.is_empty()
+    }
+
+    /// Run every registered controller concurrently, resolving as soon as the
+    /// first one stops or errors (the remaining ones are then aborted). This
+    /// mirrors the previous `tokio::select!` behaviour.
+    pub async fn run(self) -> Result<(), BoxError> {
+        let mut set = JoinSet::new();
+        for controller in self.controllers {
+            let kind = controller.kind();
+            info!(kind, "Start to listen for events of custom resource");
+            let future = controller.run();
+            // Carry the kind into the spawned future so a controller error
+            // remains tied to the resource it came from (kind is `Copy`).
+            set.spawn(async move { future.await.map_err(|err| format!("{kind}: {err}").into()) });
+        }
+
+        match set.join_next().await {
+            Some(Ok(result)) => result,
+            Some(Err(err)) => Err(Box::new(err)),
+            None => Ok(()),
+        }
+    }
+}

--- a/crates/operator/Cargo.toml
+++ b/crates/operator/Cargo.toml
@@ -13,6 +13,7 @@ readme.workspace = true
 keywords = ["kubernetes", "operator", "clevercloud", "openshift"]
 
 [dependencies]
+clever-kubernetes-operator-core = { path = "../core", version = "0.8.0" }
 axum = { version = "^0.8.1", default-features = false, features = [
     "http1",
     "tokio",

--- a/crates/operator/src/cmd/mod.rs
+++ b/crates/operator/src/cmd/mod.rs
@@ -4,8 +4,8 @@
 use std::{future::Future, io, path::PathBuf, sync::Arc};
 
 use clap::{ArgAction, Parser, Subcommand};
+use clever_kubernetes_operator_core::{BoxError, FutureController, Registry};
 use paw::ParseArgs;
-use tracing::info;
 
 use crate::{
     cmd::{configmap::ConfigMapError, crd::CustomResourceDefinitionError, secret::SecretError},
@@ -56,38 +56,12 @@ pub enum Error {
     Client(client::Error),
     #[error("failed to create clevercloud client, {0}")]
     CleverClient(clevercloud::client::Error),
-    #[error("failed to watch PostgreSql resources, {0}")]
-    WatchPostgreSql(postgresql::ReconcilerError),
-    #[error("failed to watch Redis resources, {0}")]
-    WatchRedis(redis::ReconcilerError),
-    #[error("failed to watch MySql resources, {0}")]
-    WatchMySql(mysql::ReconcilerError),
-    #[error("failed to watch ElasticSearch resources, {0}")]
-    WatchElasticSearch(elasticsearch::ReconcilerError),
-    #[error("failed to watch MongoDb resources, {0}")]
-    WatchMongoDb(mongodb::ReconcilerError),
-    #[error("failed to watch ConfigProvider resources, {0}")]
-    WatchConfigProvider(config_provider::ReconcilerError),
-    #[error("failed to watch Pulsar resources, {0}")]
-    WatchPulsar(pulsar::ReconcilerError),
-    #[error("failed to watch KV resources, {0}")]
-    WatchKV(kv::ReconcilerError),
-    #[error("failed to watch Metabase resources, {0}")]
-    WatchMetabase(metabase::ReconcilerError),
-    #[error("failed to watch Keycloak resources, {0}")]
-    WatchKeycloak(keycloak::ReconcilerError),
-    #[error("failed to watch Matomo resources, {0}")]
-    WatchMatomo(matomo::ReconcilerError),
-    #[error("failed to watch Otoroshi resources, {0}")]
-    WatchOtoroshi(otoroshi::ReconcilerError),
-    #[error("failed to watch Azimutt resources, {0}")]
-    WatchAzimutt(azimutt::ReconcilerError),
-    #[error("failed to watch Cellar resources, {0}")]
-    WatchCellar(cellar::ReconcilerError),
+    #[error("failed to run a controller, {0}")]
+    Controller(BoxError),
+    #[error("refusing to start the daemon with no controller registered")]
+    NoController,
     #[error("failed to serve http content, {0}")]
     Serve(http::server::Error),
-    #[error("failed to spawn task on tokio, {0}")]
-    Join(tokio::task::JoinError),
 }
 
 // -----------------------------------------------------------------------------
@@ -177,126 +151,55 @@ pub async fn daemon(kubeconfig: Option<PathBuf>, config: Arc<Configuration>) -> 
     // Create context to give to each reconciler
     let context = Arc::new(Context::new(kube_client, clever_client, config));
 
-    let postgresql_ctx = context.to_owned();
-    let mysql_ctx = context.to_owned();
-    let mongodb_ctx = context.to_owned();
-    let redis_ctx = context.to_owned();
-    let elasticsearch_ctx = context.to_owned();
-    let config_provider_ctx = context.to_owned();
-    let pulsar_ctx = context.to_owned();
-    let kv_ctx = context.to_owned();
-    let metabase_ctx = context.to_owned();
-    let keycloak_ctx = context.to_owned();
-    let matomo_ctx = context.to_owned();
-    let otoroshi_ctx = context.to_owned();
-    let azimutt_ctx = context.to_owned();
-    let cellar_ctx = context.to_owned();
+    // -------------------------------------------------------------------------
+    // Build the registry of controllers. Every add-on controller is registered
+    // here; running only a subset will come later with configurable modules.
+    let mut registry = Registry::new();
+
+    macro_rules! register {
+        ($($kind:literal => $module:ident),+ $(,)?) => {{
+            $(
+                let ctx = context.to_owned();
+                registry.register(FutureController::boxed($kind, async move {
+                    $module::Reconciler::default()
+                        .watch(ctx)
+                        .await
+                        .map_err(|err| Box::new(err) as BoxError)
+                }));
+            )+
+        }};
+    }
+
+    register! {
+        "PostgreSql" => postgresql,
+        "Redis" => redis,
+        "MySql" => mysql,
+        "MongoDb" => mongodb,
+        "Pulsar" => pulsar,
+        "ConfigProvider" => config_provider,
+        "ElasticSearch" => elasticsearch,
+        "KV" => kv,
+        "Metabase" => metabase,
+        "Keycloak" => keycloak,
+        "Matomo" => matomo,
+        "Otoroshi" => otoroshi,
+        "Azimutt" => azimutt,
+        "Cellar" => cellar,
+    }
+
+    // A registry with no controller would make `run()` resolve immediately and
+    // the daemon exit cleanly without watching anything — fail loudly instead.
+    // This becomes reachable once modules are configurable.
+    if registry.is_empty() {
+        return Err(Error::NoController);
+    }
 
     // -------------------------------------------------------------------------
-    // Start services
-
+    // Run the controllers alongside the termination signal and the http server;
+    // resolve as soon as any of them stops.
     tokio::select! {
-        r = tokio::spawn(async move {
-            info!(kind = "PostgreSql", "Start to listen for events of custom resource");
-            postgresql::Reconciler::default()
-                .watch(postgresql_ctx)
-                .await
-                .map_err(Error::WatchPostgreSql)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Redis", "Start to listen for events of custom resource");
-            redis::Reconciler::default()
-                .watch(redis_ctx)
-                .await
-                .map_err(Error::WatchRedis)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "MySql", "Start to listen for events of custom resource");
-            mysql::Reconciler::default()
-                .watch(mysql_ctx)
-                .await
-                .map_err(Error::WatchMySql)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "MongoDb", "Start to listen for events of custom resource");
-            mongodb::Reconciler::default()
-                .watch(mongodb_ctx)
-                .await
-                .map_err(Error::WatchMongoDb)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Pulsar", "Start to listen for events of custom resource");
-            pulsar::Reconciler::default()
-                .watch(pulsar_ctx)
-                .await
-                .map_err(Error::WatchPulsar)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "ConfigProvider", "Start to listen for events of custom resource");
-            config_provider::Reconciler::default()
-                .watch(config_provider_ctx)
-                .await
-                .map_err(Error::WatchConfigProvider)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "ElasticSearch", "Start to listen for events of custom resource");
-            elasticsearch::Reconciler::default()
-                .watch(elasticsearch_ctx)
-                .await
-                .map_err(Error::WatchElasticSearch)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "KV", "Start to listen for events of custom resource");
-            kv::Reconciler::default()
-                .watch(kv_ctx)
-                .await
-                .map_err(Error::WatchKV)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Metabase", "Start to listen for events of custom resource");
-            metabase::Reconciler::default()
-                .watch(metabase_ctx)
-                .await
-                .map_err(Error::WatchMetabase)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Keycloak", "Start to listen for events of custom resource");
-            keycloak::Reconciler::default()
-                .watch(keycloak_ctx)
-                .await
-                .map_err(Error::WatchKeycloak)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Matomo", "Start to listen for events of custom resource");
-            matomo::Reconciler::default()
-                .watch(matomo_ctx)
-                .await
-                .map_err(Error::WatchMatomo)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Otoroshi", "Start to listen for events of custom resource");
-            otoroshi::Reconciler::default()
-                .watch(otoroshi_ctx)
-                .await
-                .map_err(Error::WatchOtoroshi)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Azimutt", "Start to listen for events of custom resource");
-            azimutt::Reconciler::default()
-                .watch(azimutt_ctx)
-                .await
-                .map_err(Error::WatchAzimutt)
-        }) => r,
-        r = tokio::spawn(async move {
-            info!(kind = "Cellar", "Start to listen for events of custom resource");
-            cellar::Reconciler::default()
-                .watch(cellar_ctx)
-                .await
-                .map_err(Error::WatchCellar)
-        }) => r,
-        r = tokio::spawn(async move { tokio::signal::ctrl_c().await.map_err(Error::SigTerm) }) => r,
-        r = tokio::spawn(async move { http::server::serve(http::server::router(), context.config.operator.listen).await.map_err(Error::Serve) }) => r,
-    }.map_err(Error::Join)??;
-
-    Ok(())
+        res = registry.run() => res.map_err(Error::Controller),
+        res = tokio::signal::ctrl_c() => res.map_err(Error::SigTerm),
+        res = http::server::serve(http::server::router(), context.config.operator.listen) => res.map_err(Error::Serve),
+    }
 }


### PR DESCRIPTION
> **Stacked on PR-08 (`refactor/cargo-workspace`).** This PR is based on the PR-08 branch so its
> diff shows only the controller-registry commit. Once PR-08 is merged, GitHub will retarget this
> PR onto `main` automatically (or it can be rebased so the PR-08 commit drops out).

## What

Replace the daemon's hardcoded `tokio::select!` over 14 reconcilers with a uniform controller
abstraction in the `core` crate.

**`core`:**
- `Controller` trait — object-safe, `fn kind(&self) -> &'static str` + `fn run(self: Box<Self>)
  -> ControllerFuture`. It does **not** take a context: `Context` lives in the operator crate,
  so the context is captured inside each controller's future instead (keeps `core` free of any
  operator dependency).
- `FutureController` — bridges an already-built future (an existing reconciler's `watch` loop)
  into a `Controller`, so the reconcilers are reused unchanged without re-stating `Watcher`'s
  heavy generic bounds.
- `Registry` — holds `Vec<Box<dyn Controller>>`, runs them via a `JoinSet`, logs each start,
  and resolves as soon as the first one stops (others aborted) — **same behaviour** as the old
  `select!`, but the controller set is now dynamic.

**`operator`:**
- The `daemon` builds the registry via a local `register!` macro listing the 14 add-on
  controllers as a readable `"Kind" => module` table, then `select!`s over `registry.run()`,
  `ctrl_c` and the http server.
- The 14 per-kind `WatchX` error variants (and `Join`) collapse into a single
  `Error::Controller(BoxError)`.

## Why

R-03 / D-10: a common controller abstraction in `core` is the prerequisite for configurable
modules (R-02 — register only the enabled ones) and pluggable reconciliation strategies
(R-15 — `ExportOwned` vs `Bidirectional`).

## No behaviour change

All controllers still run; the operator stops as soon as any one of them stops. Net diff is
small (the daemon shrank a lot).

## Design notes

- **Trait without context** → no `core → operator` dependency cycle; context captured per-controller.
- **`BoxError`** → lets a heterogeneous controller set share one error variant; trade-off is
  losing the static per-kind error type (message + logged `kind` remain).
- **`FutureController` bridge** (not a generic `WatchController<T, R>`) → avoids repeating
  `Watcher<T>`'s long bounds; the temporary reconciler lives inside the async block so there's
  no borrow/lifetime issue.
- **`register!` macro** → keeps the controller list a readable table.
- Future modules can implement `Controller` directly instead of via `FutureController`.
