### PR TITLE
fix(crd): stop UpsertFinalizer event flood on failing reconciliations

### DIFF
--- a/crates/operator/src/svc/crd/azimutt.rs
+++ b/crates/operator/src/svc/crd/azimutt.rs
@@ -318,9 +318,11 @@ impl k8s::Reconciler<Azimutt> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/cellar.rs
+++ b/crates/operator/src/svc/crd/cellar.rs
@@ -340,9 +340,11 @@ impl k8s::Reconciler<Cellar> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/config_provider.rs
+++ b/crates/operator/src/svc/crd/config_provider.rs
@@ -309,9 +309,11 @@ impl k8s::Reconciler<ConfigProvider> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: upsert addon

--- a/crates/operator/src/svc/crd/elasticsearch.rs
+++ b/crates/operator/src/svc/crd/elasticsearch.rs
@@ -357,9 +357,11 @@ impl k8s::Reconciler<ElasticSearch> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/keycloak.rs
+++ b/crates/operator/src/svc/crd/keycloak.rs
@@ -363,9 +363,11 @@ impl k8s::Reconciler<Keycloak> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/kv.rs
+++ b/crates/operator/src/svc/crd/kv.rs
@@ -306,9 +306,11 @@ impl k8s::Reconciler<KV> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2:

--- a/crates/operator/src/svc/crd/matomo.rs
+++ b/crates/operator/src/svc/crd/matomo.rs
@@ -340,9 +340,11 @@ impl k8s::Reconciler<Matomo> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/metabase.rs
+++ b/crates/operator/src/svc/crd/metabase.rs
@@ -341,9 +341,11 @@ impl k8s::Reconciler<Metabase> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/mongodb.rs
+++ b/crates/operator/src/svc/crd/mongodb.rs
@@ -334,9 +334,11 @@ impl k8s::Reconciler<MongoDb> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/mysql.rs
+++ b/crates/operator/src/svc/crd/mysql.rs
@@ -334,9 +334,11 @@ impl k8s::Reconciler<MySql> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/otoroshi.rs
+++ b/crates/operator/src/svc/crd/otoroshi.rs
@@ -340,9 +340,11 @@ impl k8s::Reconciler<Otoroshi> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/postgresql.rs
+++ b/crates/operator/src/svc/crd/postgresql.rs
@@ -334,9 +334,11 @@ impl k8s::Reconciler<PostgreSql> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/crd/pulsar.rs
+++ b/crates/operator/src/svc/crd/pulsar.rs
@@ -308,9 +308,11 @@ impl k8s::Reconciler<Pulsar> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2:

--- a/crates/operator/src/svc/crd/redis.rs
+++ b/crates/operator/src/svc/crd/redis.rs
@@ -335,9 +335,11 @@ impl k8s::Reconciler<Redis> for Reconciler {
         let patch = resource::diff(&*origin, &modified).map_err(ReconcilerError::Diff)?;
         let mut modified = resource::patch(kube.to_owned(), &modified, patch).await?;
 
-        let action = &Action::UpsertFinalizer;
-        let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
-        recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        if !finalizer::contains(&*origin, ADDON_FINALIZER) {
+            let action = &Action::UpsertFinalizer;
+            let message = &format!("Create finalizer '{}'", ADDON_FINALIZER);
+            recorder::normal(kube.to_owned(), &modified, action, message).await?;
+        }
 
         // ---------------------------------------------------------------------
         // Step 2: translate plan

--- a/crates/operator/src/svc/k8s/mod.rs
+++ b/crates/operator/src/svc/k8s/mod.rs
@@ -171,10 +171,11 @@ where
 
     /// returns a [`Action`] to perform following the given error
     fn retry(_obj: Arc<T>, err: &Self::Error, _ctx: Arc<Context>) -> Action {
-        // Implements a basic reconciliation which always re-schedule the event
-        // 500 ms later
-        trace!("Requeue failed reconciliation for 500ms, {}", err);
-        Action::requeue(Duration::from_millis(500))
+        // Re-schedule the reconciliation after a pause. A persistent failure
+        // (e.g. an unreachable or rejecting upstream api) would otherwise
+        // hammer both the kubernetes and clever-cloud apis in a tight loop
+        trace!("Requeue failed reconciliation for 30s, {}", err);
+        Action::requeue(Duration::from_secs(30))
     }
 
     /// process the object and perform actions on kubernetes and/or


### PR DESCRIPTION
## Context

A custom resource whose reconciliation keeps failing causes the operator to emit a steady stream of `Normal UpsertFinalizer` events, creating a new Event object every second per resource. Over time this grows the events keyspace in etcd unboundedly and puts sustained load on both the kubernetes apiserver and the Clever Cloud API.

## Root cause

Two compounding issues:

1. **`UpsertFinalizer` event emitted on every reconcile pass.** Step 1 of every `upsert` reconciliation records the event unconditionally, even when the finalizer is already present (the patch itself is already skipped as an empty diff by `resource::ipatch`, but the event is not). Since `recorder::event::new` names events `{cr}-{action}-{unix second}`, every pass creates a *distinct* Event object in etcd.
2. **500ms error requeue with no backoff.** `Reconciler::retry` requeues failed reconciliations every 500ms forever. A CR whose reconciliation persistently fails *after* Step 1 therefore runs ~2 passes/second, emitting one event per pass and retrying against the apis in a tight loop.

## Changes

- `fix(crd)`: in all 14 CRD reconcilers, record the `UpsertFinalizer` event only when the finalizer is actually missing from the resource (i.e. genuinely added).
- `fix(k8s)`: raise the default failed-reconciliation requeue from 500ms to 30s. The retry policy is stateless so a true exponential backoff is not available here; a fixed 30s delay keeps recovery reasonably fast while cutting the retry load by ~60x.

With the first commit alone, a stuck CR no longer produces any event flood; the second is defense-in-depth for API load.

## Testing

- `cargo check --workspace`, `cargo clippy --workspace` and `cargo fmt` are clean.
- Verified the guarded block is strictly identical across the 14 CRD reconcilers before patching.

